### PR TITLE
Fix: make GYB setup executable and GYB on path

### DIFF
--- a/.devcontainer/postAttach.sh
+++ b/.devcontainer/postAttach.sh
@@ -2,3 +2,5 @@
 set -eu
 
 pre-commit install --install-hooks
+
+echo -e "\nexport PATH=$PATH:/home/compiler/admin/.config/gyb" >> ~/.bashrc

--- a/compiler_admin/commands/init.py
+++ b/compiler_admin/commands/init.py
@@ -28,7 +28,7 @@ def init(args: Namespace) -> int:
     See https://github.com/taers232c/GAMADV-XTD3/wiki/How-to-Install-Advanced-GAM
 
     Args:
-        admin_user (str): The Compiler admin with which to initialize a new project.
+        username (str): The Compiler admin with which to initialize a new project.
 
         gam (bool): If True, initialize a new GAM project.
 
@@ -37,10 +37,10 @@ def init(args: Namespace) -> int:
     Returns:
         A value indicating if the operation succeeded or failed.
     """
-    if not hasattr(args, "admin_user"):
-        raise ValueError("admin_user is required")
+    if not hasattr(args, "username"):
+        raise ValueError("username is required")
 
-    admin_user = args.admin_user
+    admin_user = args.username
     res = RESULT_SUCCESS
 
     if getattr(args, "gam", False):

--- a/compiler_admin/commands/init.py
+++ b/compiler_admin/commands/init.py
@@ -58,6 +58,8 @@ def init(args: Namespace) -> int:
         with gyb.open("w+") as dest:
             res += subprocess.call(("curl", "-s", "-S", "-L", "https://gyb-shortn.jaylee.us/gyb-install"), stdout=dest)
 
+        res += subprocess.call(("chmod", "+x", str(gyb.absolute())))
+
         # install, giving values to some options
         # https://github.com/GAM-team/got-your-back/blob/main/install-gyb.sh
         #

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -55,12 +55,12 @@ def test_clean_config_dir(mocker, mock_GAM_CONFIG_PATH, mock_rmtree):
 def test_init_admin_user_required():
     args = Namespace()
 
-    with pytest.raises(ValueError, match="admin_user is required"):
+    with pytest.raises(ValueError, match="username is required"):
         init(args)
 
 
 def test_init_default(mock_clean_config_dir, mock_google_CallGAMCommand, mock_subprocess_call):
-    args = Namespace(admin_user="username")
+    args = Namespace(username="username")
     init(args)
 
     assert mock_clean_config_dir.call_count == 0
@@ -69,7 +69,7 @@ def test_init_default(mock_clean_config_dir, mock_google_CallGAMCommand, mock_su
 
 
 def test_init_gam(mock_GAM_CONFIG_PATH, mock_clean_config_dir, mock_google_CallGAMCommand):
-    args = Namespace(admin_user="username", gam=True, gyb=False)
+    args = Namespace(username="username", gam=True, gyb=False)
     init(args)
 
     mock_clean_config_dir.assert_called_once()
@@ -78,7 +78,7 @@ def test_init_gam(mock_GAM_CONFIG_PATH, mock_clean_config_dir, mock_google_CallG
 
 
 def test_init_gyb(mock_GYB_CONFIG_PATH, mock_clean_config_dir, mock_subprocess_call):
-    args = Namespace(admin_user="username", gam=False, gyb=True)
+    args = Namespace(username="username", gam=False, gyb=True)
     init(args)
 
     mock_clean_config_dir.assert_called_once()


### PR DESCRIPTION
More fixes for GYB when the devcontainer restarts/rebuilds.

Also correct a parameter name error in `commands.init` -- should be `username` added by the `_subcmd` helper.