### PR TITLE
Feat: download Toggl detailed time reports as CSV

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,3 +8,5 @@ TOGGL_USER_INFO=data/toggl-user-info-sample.json
 TOGGL_API_TOKEN=token
 TOGGL_CLIENT_ID=client
 TOGGL_WORKSPACE_ID=workspace
+
+TZ_NAME=America/Los_Angeles

--- a/.env.sample
+++ b/.env.sample
@@ -4,3 +4,7 @@ HARVEST_DATA=data/harvest-sample.csv
 TOGGL_DATA=data/toggl-sample.csv
 TOGGL_PROJECT_INFO=data/toggl-project-info-sample.json
 TOGGL_USER_INFO=data/toggl-user-info-sample.json
+
+TOGGL_API_TOKEN=token
+TOGGL_CLIENT_ID=client
+TOGGL_WORKSPACE_ID=workspace

--- a/README.md
+++ b/README.md
@@ -80,12 +80,17 @@ Use this command to download a time report from Toggl in CSV format:
 ```bash
 $ compiler-admin time download -h
 usage: compiler-admin time download [-h] [--start YYYY-MM-DD] [--end YYYY-MM-DD] [--output OUTPUT]
+                                    [--client CLIENT_ID] [--project PROJECT_ID] [--task TASK_ID] [--user USER_ID]
 
 options:
-  -h, --help          show this help message and exit
-  --start YYYY-MM-DD  The start date of the reporting period. Defaults to the beginning of the prior month.
-  --end YYYY-MM-DD    The end date of the reporting period. Defaults to the end of the prior month.
-  --output OUTPUT     The path to the file where converted data should be written. Defaults to stdout.
+  -h, --help            show this help message and exit
+  --start YYYY-MM-DD    The start date of the reporting period. Defaults to the beginning of the prior month.
+  --end YYYY-MM-DD      The end date of the reporting period. Defaults to the end of the prior month.
+  --output OUTPUT       The path to the file where converted data should be written. Defaults to stdout.
+  --client CLIENT_ID    An ID for a Toggl Client to filter for in reports. Can be supplied more than once.
+  --project PROJECT_ID  An ID for a Toggl Project to filter for in reports. Can be supplied more than once.
+  --task TASK_ID        An ID for a Toggl Project Task to filter for in reports. Can be supplied more than once.
+  --user USER_ID        An ID for a Toggl User to filter for in reports. Can be supplied more than once.
 ```
 
 ### Converting an hours report

--- a/README.md
+++ b/README.md
@@ -62,14 +62,30 @@ The `time` command provides an interface for working with time entries from Comp
 
 ```bash
 $ compiler-admin time -h
-usage: compiler-admin time [-h] {convert} ...
+usage: compiler-admin time [-h] {convert,download} ...
 
 positional arguments:
-  {convert}   The time command to run.
-    convert   Convert a time report from one format into another.
+  {convert,download}  The time command to run.
+    convert           Convert a time report from one format into another.
+    download          Download a Toggl report in CSV format.
 
 options:
-  -h, --help  show this help message and exit
+  -h, --help          show this help message and exit
+```
+
+### Downloading a Toggl report
+
+Use this command to download a time report from Toggl in CSV format:
+
+```bash
+$ compiler-admin time download -h
+usage: compiler-admin time download [-h] [--start YYYY-MM-DD] [--end YYYY-MM-DD] [--output OUTPUT]
+
+options:
+  -h, --help          show this help message and exit
+  --start YYYY-MM-DD  The start date of the reporting period. Defaults to the beginning of the prior month.
+  --end YYYY-MM-DD    The end date of the reporting period. Defaults to the end of the prior month.
+  --output OUTPUT     The path to the file where converted data should be written. Defaults to stdout.
 ```
 
 ### Converting an hours report

--- a/compiler_admin/commands/time/__init__.py
+++ b/compiler_admin/commands/time/__init__.py
@@ -1,6 +1,7 @@
 from argparse import Namespace
 
 from compiler_admin.commands.time.convert import convert  # noqa: F401
+from compiler_admin.commands.time.download import download  # noqa: F401
 
 
 def time(args: Namespace, *extra):

--- a/compiler_admin/commands/time/download.py
+++ b/compiler_admin/commands/time/download.py
@@ -5,6 +5,17 @@ from compiler_admin.services.toggl import INPUT_COLUMNS as TOGGL_COLUMNS, downlo
 
 
 def download(args: Namespace, *extras):
-    download_time_entries(args.start, args.end, args.output, TOGGL_COLUMNS)
+    params = dict(start_date=args.start, end_date=args.end, output_path=args.output, output_cols=TOGGL_COLUMNS)
+
+    if args.client_ids:
+        params.update(dict(client_ids=args.client_ids))
+    if args.project_ids:
+        params.update(dict(project_ids=args.project_ids))
+    if args.task_ids:
+        params.update(dict(task_ids=args.task_ids))
+    if args.user_ids:
+        params.update(dict(user_ids=args.user_ids))
+
+    download_time_entries(**params)
 
     return RESULT_SUCCESS

--- a/compiler_admin/commands/time/download.py
+++ b/compiler_admin/commands/time/download.py
@@ -1,0 +1,10 @@
+from argparse import Namespace
+
+from compiler_admin import RESULT_SUCCESS
+from compiler_admin.services.toggl import INPUT_COLUMNS as TOGGL_COLUMNS, download_time_entries
+
+
+def download(args: Namespace, *extras):
+    download_time_entries(args.start, args.end, args.output, TOGGL_COLUMNS)
+
+    return RESULT_SUCCESS

--- a/compiler_admin/main.py
+++ b/compiler_admin/main.py
@@ -94,6 +94,38 @@ def setup_time_command(cmd_parsers: _SubParsersAction):
     time_download.add_argument(
         "--output", default=sys.stdout, help="The path to the file where converted data should be written. Defaults to stdout."
     )
+    time_download.add_argument(
+        "--client",
+        dest="client_ids",
+        metavar="CLIENT_ID",
+        action="append",
+        type=int,
+        help="An ID for a Toggl Client to filter for in reports. Can be supplied more than once.",
+    )
+    time_download.add_argument(
+        "--project",
+        dest="project_ids",
+        metavar="PROJECT_ID",
+        action="append",
+        type=int,
+        help="An ID for a Toggl Project to filter for in reports. Can be supplied more than once.",
+    )
+    time_download.add_argument(
+        "--task",
+        dest="task_ids",
+        metavar="TASK_ID",
+        action="append",
+        type=int,
+        help="An ID for a Toggl Project Task to filter for in reports. Can be supplied more than once.",
+    )
+    time_download.add_argument(
+        "--user",
+        dest="user_ids",
+        metavar="USER_ID",
+        action="append",
+        type=int,
+        help="An ID for a Toggl User to filter for in reports. Can be supplied more than once.",
+    )
 
 
 def setup_user_command(cmd_parsers: _SubParsersAction):

--- a/compiler_admin/main.py
+++ b/compiler_admin/main.py
@@ -76,6 +76,25 @@ def setup_time_command(cmd_parsers: _SubParsersAction):
     )
     time_convert.add_argument("--client", default=None, help="The name of the client to use in converted data.")
 
+    time_download = add_sub_cmd(time_subcmds, "download", help="Download a Toggl report in CSV format.")
+    time_download.add_argument(
+        "--start",
+        metavar="YYYY-MM-DD",
+        default=prior_month_start(),
+        type=lambda s: TZINFO.localize(datetime.strptime(s, "%Y-%m-%d")),
+        help="The start date of the reporting period. Defaults to the beginning of the prior month.",
+    )
+    time_download.add_argument(
+        "--end",
+        metavar="YYYY-MM-DD",
+        default=prior_month_end(),
+        type=lambda s: TZINFO.localize(datetime.strptime(s, "%Y-%m-%d")),
+        help="The end date of the reporting period. Defaults to the end of the prior month.",
+    )
+    time_download.add_argument(
+        "--output", default=sys.stdout, help="The path to the file where converted data should be written. Defaults to stdout."
+    )
+
 
 def setup_user_command(cmd_parsers: _SubParsersAction):
     user_cmd = add_sub_cmd(cmd_parsers, "user", help="Work with users in the Compiler org.")

--- a/compiler_admin/main.py
+++ b/compiler_admin/main.py
@@ -1,5 +1,9 @@
 from argparse import ArgumentParser, _SubParsersAction
+from datetime import datetime, timedelta
+import os
 import sys
+
+from pytz import timezone
 
 from compiler_admin import __version__ as version
 from compiler_admin.commands.info import info
@@ -7,6 +11,24 @@ from compiler_admin.commands.init import init
 from compiler_admin.commands.time import time
 from compiler_admin.commands.user import user
 from compiler_admin.commands.user.convert import ACCOUNT_TYPE_OU
+
+
+TZINFO = timezone(os.environ.get("TZ_NAME", "America/Los_Angeles"))
+
+
+def local_now():
+    return datetime.now(tz=TZINFO)
+
+
+def prior_month_end():
+    now = local_now()
+    first = now.replace(day=1)
+    return first - timedelta(days=1)
+
+
+def prior_month_start():
+    end = prior_month_end()
+    return end.replace(day=1)
 
 
 def add_sub_cmd_parser(parser: ArgumentParser, dest="subcommand", help=None):

--- a/compiler_admin/services/toggl.py
+++ b/compiler_admin/services/toggl.py
@@ -221,6 +221,10 @@ def download_time_entries(
     """
     start = start_date.strftime("%Y-%m-%d")
     end = end_date.strftime("%Y-%m-%d")
+    # calculate a timeout based on the size of the reporting period in days
+    # approximately 5 seconds per month of query size, with a minimum of 5 seconds
+    range_days = (end_date - start_date).days
+    timeout = int((max(30, range_days) / 30.0) * 5)
 
     if ("client_ids" not in kwargs or not kwargs["client_ids"]) and isinstance(_toggl_client_id(), int):
         kwargs["client_ids"] = [_toggl_client_id()]
@@ -237,7 +241,7 @@ def download_time_entries(
     headers = _toggl_api_headers()
     url = _toggl_api_report_url("search/time_entries.csv")
 
-    response = requests.post(url, json=params, headers=headers, timeout=5)
+    response = requests.post(url, json=params, headers=headers, timeout=timeout)
     response.raise_for_status()
 
     # the raw response has these initial 3 bytes:

--- a/notebooks/download-and-convert.ipynb
+++ b/notebooks/download-and-convert.ipynb
@@ -1,0 +1,64 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from datetime import datetime\n",
+        "\n",
+        "from compiler_admin.services.toggl import download_time_entries, convert_to_harvest"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "start = datetime(2024, 9, 1)\n",
+        "end = datetime(2024, 9, 24)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "download_time_entries(start, end, \"data/time_entries.csv\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "convert_to_harvest(\"data/time_entries.csv\", \"data/time_entries_harvest.csv\")"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.9"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dev = [
 test = [
     "coverage",
     "pytest",
-    "pytest-mock"
+    "pytest-mock",
+    "pytest-socket"
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ source = ["compiler_admin"]
 
 [tool.pyright]
 include = ["compiler_admin", "tests"]
+typeCheckingMode = "off"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ requires-python = ">=3.11"
 dependencies = [
     "advanced-gam-for-google-workspace @ git+https://github.com/taers232c/GAMADV-XTD3.git@v7.00.05#subdirectory=src",
     "pandas==2.2.3",
+    "tzdata",
 ]
 
 [project.urls]

--- a/tests/commands/time/test_download.py
+++ b/tests/commands/time/test_download.py
@@ -13,9 +13,42 @@ def mock_download_time_entries(mocker):
 
 def test_download_default(mock_download_time_entries):
     date = datetime.now()
-    args = Namespace(start=date, end=date, output="output")
+    args = Namespace(
+        start=date,
+        end=date,
+        output="output",
+        client_ids=None,
+        project_ids=None,
+        task_ids=None,
+        user_ids=None,
+    )
 
     res = download(args)
 
     assert res == RESULT_SUCCESS
-    mock_download_time_entries.assert_called_once_with(args.start, args.end, args.output, TOGGL_COLUMNS)
+    mock_download_time_entries.assert_called_once_with(
+        start_date=args.start,
+        end_date=args.end,
+        output_path=args.output,
+        output_cols=TOGGL_COLUMNS,
+    )
+
+
+def test_download_ids(mock_download_time_entries):
+    date = datetime.now()
+    ids = [1, 2, 3]
+    args = Namespace(start=date, end=date, output="output", client_ids=ids, project_ids=ids, task_ids=ids, user_ids=ids)
+
+    res = download(args)
+
+    assert res == RESULT_SUCCESS
+    mock_download_time_entries.assert_called_once_with(
+        start_date=args.start,
+        end_date=args.end,
+        output_path=args.output,
+        output_cols=TOGGL_COLUMNS,
+        client_ids=ids,
+        project_ids=ids,
+        task_ids=ids,
+        user_ids=ids,
+    )

--- a/tests/commands/time/test_download.py
+++ b/tests/commands/time/test_download.py
@@ -1,0 +1,21 @@
+from argparse import Namespace
+from datetime import datetime
+import pytest
+
+from compiler_admin import RESULT_SUCCESS
+from compiler_admin.commands.time.download import __name__ as MODULE, download, TOGGL_COLUMNS
+
+
+@pytest.fixture
+def mock_download_time_entries(mocker):
+    return mocker.patch(f"{MODULE}.download_time_entries")
+
+
+def test_download_default(mock_download_time_entries):
+    date = datetime.now()
+    args = Namespace(start=date, end=date, output="output")
+
+    res = download(args)
+
+    assert res == RESULT_SUCCESS
+    mock_download_time_entries.assert_called_once_with(args.start, args.end, args.output, TOGGL_COLUMNS)

--- a/tests/commands/user/test_convert.py
+++ b/tests/commands/user/test_convert.py
@@ -172,7 +172,7 @@ def test_convert_partner(mock_google_add_user_to_group, mock_google_move_user_ou
     res = convert(args)
 
     assert res == RESULT_SUCCESS
-    mock_google_add_user_to_group.call_count == 2
+    assert mock_google_add_user_to_group.call_count == 2
     mock_google_move_user_ou.assert_called_once()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,11 @@
 import pytest
+from pytest_socket import disable_socket
 
 from compiler_admin import RESULT_SUCCESS
+
+
+def pytest_runtest_setup():
+    disable_socket()
 
 
 @pytest.fixture

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -114,6 +114,41 @@ def test_main_time_convert_default(mock_commands_time):
     )
 
 
+@pytest.mark.usefixtures("mock_local_now")
+def test_main_time_download_default(mock_commands_time, mock_start, mock_end):
+    main(argv=["time", "download"])
+
+    mock_commands_time.assert_called_once()
+    call_args = mock_commands_time.call_args.args
+    assert (
+        Namespace(
+            func=mock_commands_time, command="time", subcommand="download", start=mock_start, end=mock_end, output=sys.stdout
+        )
+        in call_args
+    )
+
+
+def test_main_time_download_args(mock_commands_time):
+    main(argv=["time", "download", "--start", "2024-01-01", "--end", "2024-01-31", "--output", "file.csv"])
+
+    expected_start = TZINFO.localize(datetime(2024, 1, 1))
+    expected_end = TZINFO.localize(datetime(2024, 1, 31))
+
+    mock_commands_time.assert_called_once()
+    call_args = mock_commands_time.call_args.args
+    assert (
+        Namespace(
+            func=mock_commands_time,
+            command="time",
+            subcommand="download",
+            start=expected_start,
+            end=expected_end,
+            output="file.csv",
+        )
+        in call_args
+    )
+
+
 def test_main_time_convert_client(mock_commands_time):
     main(argv=["time", "convert", "--client", "client123"])
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,12 +1,30 @@
 from argparse import Namespace
+from datetime import datetime
 import subprocess
 import sys
 
 import pytest
 
 import compiler_admin.main
-from compiler_admin.main import main, __name__ as MODULE
+from compiler_admin.main import main, prior_month_start, prior_month_end, TZINFO, __name__ as MODULE
 from compiler_admin.services.google import DOMAIN
+
+
+@pytest.fixture
+def mock_local_now(mocker):
+    dt = datetime(2024, 9, 25, tzinfo=TZINFO)
+    mocker.patch(f"{MODULE}.local_now", return_value=dt)
+    return dt
+
+
+@pytest.fixture
+def mock_start(mock_local_now):
+    return datetime(2024, 8, 1, tzinfo=TZINFO)
+
+
+@pytest.fixture
+def mock_end(mock_local_now):
+    return datetime(2024, 8, 31, tzinfo=TZINFO)
 
 
 @pytest.fixture
@@ -27,6 +45,18 @@ def mock_commands_time(mock_commands_time):
 @pytest.fixture
 def mock_commands_user(mock_commands_user):
     return mock_commands_user(MODULE)
+
+
+def test_prior_month_start(mock_start):
+    start = prior_month_start()
+
+    assert start == mock_start
+
+
+def test_prior_month_end(mock_end):
+    end = prior_month_end()
+
+    assert end == mock_end
 
 
 def test_main_info(mock_commands_info):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -122,17 +122,62 @@ def test_main_time_download_default(mock_commands_time, mock_start, mock_end):
     call_args = mock_commands_time.call_args.args
     assert (
         Namespace(
-            func=mock_commands_time, command="time", subcommand="download", start=mock_start, end=mock_end, output=sys.stdout
+            func=mock_commands_time,
+            command="time",
+            subcommand="download",
+            start=mock_start,
+            end=mock_end,
+            output=sys.stdout,
+            client_ids=None,
+            project_ids=None,
+            task_ids=None,
+            user_ids=None,
         )
         in call_args
     )
 
 
 def test_main_time_download_args(mock_commands_time):
-    main(argv=["time", "download", "--start", "2024-01-01", "--end", "2024-01-31", "--output", "file.csv"])
+    main(
+        argv=[
+            "time",
+            "download",
+            "--start",
+            "2024-01-01",
+            "--end",
+            "2024-01-31",
+            "--output",
+            "file.csv",
+            "--client",
+            "1",
+            "--client",
+            "2",
+            "--client",
+            "3",
+            "--project",
+            "1",
+            "--project",
+            "2",
+            "--project",
+            "3",
+            "--task",
+            "1",
+            "--task",
+            "2",
+            "--task",
+            "3",
+            "--user",
+            "1",
+            "--user",
+            "2",
+            "--user",
+            "3",
+        ]
+    )
 
     expected_start = TZINFO.localize(datetime(2024, 1, 1))
     expected_end = TZINFO.localize(datetime(2024, 1, 31))
+    ids = [1, 2, 3]
 
     mock_commands_time.assert_called_once()
     call_args = mock_commands_time.call_args.args
@@ -144,6 +189,10 @@ def test_main_time_download_args(mock_commands_time):
             start=expected_start,
             end=expected_end,
             output="file.csv",
+            client_ids=ids,
+            project_ids=ids,
+            task_ids=ids,
+            user_ids=ids,
         )
         in call_args
     )


### PR DESCRIPTION
Part of #25 

## New command

```bash
$ compiler-admin time download -h
usage: compiler-admin time download [-h] [--start YYYY-MM-DD] [--end YYYY-MM-DD] [--output OUTPUT]
                                    [--client CLIENT_ID] [--project PROJECT_ID] [--task TASK_ID] [--user USER_ID]

options:
  -h, --help            show this help message and exit
  --start YYYY-MM-DD    The start date of the reporting period. Defaults to the beginning of the prior month.
  --end YYYY-MM-DD      The end date of the reporting period. Defaults to the end of the prior month.
  --output OUTPUT       The path to the file where converted data should be written. Defaults to stdout.
  --client CLIENT_ID    An ID for a Toggl Client to filter for in reports. Can be supplied more than once.
  --project PROJECT_ID  An ID for a Toggl Project to filter for in reports. Can be supplied more than once.
  --task TASK_ID        An ID for a Toggl Project Task to filter for in reports. Can be supplied more than once.
  --user USER_ID        An ID for a Toggl User to filter for in reports. Can be supplied more than once.
```

## Example usage

All defaults

```bash
compiler-admin time download
```

Custom date range

```bash
compiler-admin time download --start 2024-09-01 --end 2024-09-30
```

Custom output file

```bash
compiler-admin time download --output /path/to/file.csv
```

Filter projects

```bash
compiler-admin time download --project 1234 --project 5678
```

Filter users

```bash
compiler-admin time download --user 1234 --user 5678
```

## Required `.env`

An API token and Workspace ID for Toggl are required

```env
TOGGL_API_TOKEN=token
TOGGL_WORKSPACE_ID=workspace
```

## Optional `.env`

Default filter for a Toggl Client

```env
TOGGL_CLIENT_ID=client
```