### PR TITLE
Fix: devcontainer config

### DIFF
--- a/.config/README.md
+++ b/.config/README.md
@@ -1,6 +1,0 @@
-# `.config` directory
-
-This directory is where local GAM and GYB configuration is stored.
-
-The directoy's contents (except for this README) are ignored in `.gitignore` to
-avoid committing sensitive information.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,8 +9,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 RUN useradd --create-home --shell /bin/bash $USER
 
 USER $USER
-ENV PATH="$PATH:/home/$USER/.local/bin"
 RUN mkdir -p /home/$USER/.config/compiler-admin
+ENV PATH="$PATH:/home/$USER/.local/bin:/home/$USER/.config/compiler-admin/gyb"
 WORKDIR /home/$USER/compiler-admin
 
 RUN python -m pip install --upgrade pip

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,8 +9,9 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 RUN useradd --create-home --shell /bin/bash $USER
 
 USER $USER
-ENV PATH "$PATH:/home/$USER/.local/bin"
-WORKDIR /home/$USER/admin
+ENV PATH="$PATH:/home/$USER/.local/bin"
+RUN mkdir -p /home/$USER/.config/compiler-admin
+WORKDIR /home/$USER/compiler-admin
 
 RUN python -m pip install --upgrade pip
 
@@ -20,7 +21,7 @@ COPY pyproject.toml pyproject.toml
 RUN pip install -e .[dev,test]
 
 USER root
-RUN chown -R $USER /home/$USER
+RUN chown -R $USER:$USER /home/$USER
 USER $USER
 
 CMD ["sleep", "infinity"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "name": "compilerla/admin",
   "dockerComposeFile": ["../compose.yaml"],
   "service": "dev",
-  "workspaceFolder": "/home/compiler/admin",
+  "workspaceFolder": "/home/compiler/compiler-admin",
   "postAttachCommand": ["/bin/bash", ".devcontainer/postAttach.sh"],
   "customizations": {
     "vscode": {

--- a/.devcontainer/postAttach.sh
+++ b/.devcontainer/postAttach.sh
@@ -3,4 +3,4 @@ set -eu
 
 pre-commit install --install-hooks
 
-echo -e "\nexport PATH=$PATH:/home/compiler/admin/.config/gyb" >> ~/.bashrc
+echo -e "\nexport PATH=$PATH:/home/$USER/.config/compiler-admin/gyb" >> ~/.bashrc

--- a/.devcontainer/postAttach.sh
+++ b/.devcontainer/postAttach.sh
@@ -2,5 +2,3 @@
 set -eu
 
 pre-commit install --install-hooks
-
-echo -e "\nexport PATH=$PATH:/home/$USER/.config/compiler-admin/gyb" >> ~/.bashrc

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 GYB-GMail-Backup-*/
 __pycache__
 .config/*
-!.config/README.md
 .coverage
 .downloads
 .env

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ options:
 ## Getting started
 
 ```bash
+mkdir -p ~/.config/compiler-admin
+
 git clone https://github.com/compilerla/compiler-admin.git
 
 cd compiler-admin

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,6 +8,6 @@ services:
       - .env
     entrypoint: sleep infinity
     volumes:
-      - .:/home/compiler/admin
-      - ./.config:/home/compiler/.config/compiler-admin
+      - .:/home/compiler/compiler-admin
+      - ~/.config/compiler-admin:/home/compiler/.config/compiler-admin
       - ./.downloads:/home/compiler/Downloads


### PR DESCRIPTION
Seems like the `postAttach.sh` script adding the PATH export was breaking the usage of `code` within the devcontainer. This was super annoying for e.g. `git commit --amend` when the default editor is set to `code`!

Also cleans up the repo-local `.config/` directory (which was ignored) to just use a workstation-local `~/.config/compiler-admin`.