### PR TITLE
Fix: JsonFileCache contains

### DIFF
--- a/compiler_admin/services/files.py
+++ b/compiler_admin/services/files.py
@@ -40,6 +40,9 @@ class JsonFileCache:
         if self._path and self._path.exists():
             self._cache.update(read_json(self._path))
 
+    def __contains__(self, key):
+        return key in self._cache
+
     def __getitem__(self, key):
         return self._cache.get(key)
 

--- a/tests/services/test_files.py
+++ b/tests/services/test_files.py
@@ -92,6 +92,7 @@ def test_JsonFileCache(monkeypatch):
         cache = JsonFileCache("INFO_FILE")
 
         assert cache._path.exists()
+        assert "key" in cache
         assert cache.get("key") == "value"
         assert cache["key"] == "value"
         assert cache.get("other") is None
@@ -108,3 +109,4 @@ def test_JsonFileCache_no_file():
     assert cache._cache == {}
     assert cache._path is None
     assert cache.get("key") is None
+    assert "key" not in cache


### PR DESCRIPTION
Need to implement `__contains__` so that `"key" in cache` syntax works.

E.g. https://github.com/compilerla/compiler-admin/blob/main/compiler_admin/services/toggl.py#L32

```python
if email in USER_INFO:
    USER_INFO[email].update(data)
else:
    USER_INFO[email] = data
```