### PR TITLE
Refactor: service classes

### DIFF
--- a/compiler_admin/api/toggl.py
+++ b/compiler_admin/api/toggl.py
@@ -6,39 +6,28 @@ import requests
 from compiler_admin import __version__
 
 
-class Toggl:
-    """Toggl API Client.
+class TogglBase:
+    """Base class for Toggl API clients.
 
     See https://engineering.toggl.com/docs/.
+
+    Sub-classes should implement api_url_resource(self).
     """
 
     API_BASE_URL = "https://api.track.toggl.com"
-    API_REPORTS_BASE_URL = "reports/api/v3"
-    API_VERSION_URL = "api/v9"
-    API_WORKSPACE = "workspace/{}"
-    API_WORKSPACES = "workspaces/{}"
+    API_VERSION = "api/v9"
     API_HEADERS = {"Content-Type": "application/json", "User-Agent": "compilerla/compiler-admin:{}".format(__version__)}
 
     def __init__(self, api_token: str, workspace_id: int, **kwargs):
         self._token = api_token
         self.workspace_id = workspace_id
 
-        self.headers = dict(Toggl.API_HEADERS)
+        self.headers = dict(TogglBase.API_HEADERS)
         self.headers.update(self._authorization_header())
 
         self.session = requests.Session()
         self.session.headers.update(self.headers)
         self.timeout = int(kwargs.get("timeout", 5))
-
-    @property
-    def workspace_url_fragment(self):
-        """The workspace portion of an API URL."""
-        return Toggl.API_WORKSPACE.format(self.workspace_id)
-
-    @property
-    def workspaces_url_fragment(self):
-        """The workspaces portion of an API URL."""
-        return Toggl.API_WORKSPACES.format(self.workspace_id)
 
     def _authorization_header(self):
         """Gets an `Authorization: Basic xyz` header using the Toggl API token.
@@ -49,16 +38,32 @@ class Toggl:
         creds64 = b64encode(bytes(creds, "utf-8")).decode("utf-8")
         return {"Authorization": "Basic {}".format(creds64)}
 
-    def _make_api_url(self, endpoint: str):
-        """Get a fully formed URL for the Toggl API version endpoint."""
-        return "/".join((Toggl.API_BASE_URL, Toggl.API_VERSION_URL, self.workspaces_url_fragment, endpoint))
+    @property
+    def api_url_resource(self):
+        """Sub-classes should implement this prop to use make_api_url() for the given API resource."""
+        raise NotImplementedError("Implement this property to use make_api_url().")
 
-    def _make_report_url(self, endpoint: str):
-        """Get a fully formed URL for the Toggl Reports API v3 endpoint.
+    @property
+    def api_url_version(self):
+        """The version information for an API request URL."""
+        return self.API_VERSION
 
-        See https://engineering.toggl.com/docs/reports_start.
-        """
-        return "/".join((Toggl.API_BASE_URL, Toggl.API_REPORTS_BASE_URL, self.workspace_url_fragment, endpoint))
+    def make_api_url(self, endpoint: str):
+        """Get a fully formed and versioned URL for an endpoint within the Toggl API."""
+        return "/".join((TogglBase.API_BASE_URL, self.api_url_version, self.api_url_resource, endpoint))
+
+
+class TogglReports(TogglBase):
+    REPORTS_API_VERSION = "reports/api/v3"
+    WORKSPACE_ID = "workspace/{}"
+
+    @property
+    def api_url_resource(self):
+        return self.WORKSPACE_ID.format(self.workspace_id)
+
+    @property
+    def api_url_version(self):
+        return self.REPORTS_API_VERSION
 
     def detailed_time_entries(self, start_date: datetime, end_date: datetime, **kwargs) -> requests.Response:
         """Request a CSV report from Toggl of detailed time entries for the given date range.
@@ -113,19 +118,28 @@ class Toggl:
 
         See https://engineering.toggl.com/docs/reports_start.
         """
-        url = self._make_report_url(endpoint)
+        url = self.make_api_url(endpoint)
 
         response = self.session.post(url, json=kwargs, timeout=self.timeout)
         response.raise_for_status()
 
         return response
 
-    def update_workspace_preferences(self, **kwargs) -> requests.Response:
+
+class TogglWorkspace(TogglBase):
+    WORKSPACES_ID = "workspaces/{}"
+
+    @property
+    def api_url_resource(self):
+        """The workspaces portion of an API URL."""
+        return self.WORKSPACES_ID.format(self.workspace_id)
+
+    def update_preferences(self, **kwargs) -> requests.Response:
         """Update workspace preferences.
 
         See https://engineering.toggl.com/docs/api/preferences/#post-update-workspace-preferences.
         """
-        url = self._make_api_url("preferences")
+        url = self.make_api_url("preferences")
 
         response = self.session.post(url, json=kwargs, timeout=self.timeout)
         response.raise_for_status()

--- a/compiler_admin/commands/time/convert.py
+++ b/compiler_admin/commands/time/convert.py
@@ -4,16 +4,17 @@ from typing import TextIO
 
 import click
 
-from compiler_admin.services.harvest import CONVERTERS as HARVEST_CONVERTERS
-from compiler_admin.services.toggl import CONVERTERS as TOGGL_CONVERTERS
+from compiler_admin.services.harvest import HarvestTime
+from compiler_admin.services.toggl import TogglTime
 
-CONVERTERS = {"harvest": HARVEST_CONVERTERS, "toggl": TOGGL_CONVERTERS}
+TIME_SERVICES = {"harvest": HarvestTime(), "toggl": TogglTime()}
 
 
 def _get_source_converter(from_fmt: str, to_fmt: str):
     from_fmt = from_fmt.lower().strip() if from_fmt else ""
     to_fmt = to_fmt.lower().strip() if to_fmt else ""
-    converter = CONVERTERS.get(from_fmt, {}).get(to_fmt)
+    time_service = TIME_SERVICES.get(from_fmt, None)
+    converter = time_service.converters.get(to_fmt) if time_service else None
 
     if converter:
         return converter
@@ -40,7 +41,7 @@ def _get_source_converter(from_fmt: str, to_fmt: str):
     default="toggl",
     help="The format of the source data.",
     show_default=True,
-    type=click.Choice(sorted(CONVERTERS.keys()), case_sensitive=False),
+    type=click.Choice(sorted(TIME_SERVICES.keys()), case_sensitive=False),
 )
 @click.option(
     "--to",
@@ -48,7 +49,9 @@ def _get_source_converter(from_fmt: str, to_fmt: str):
     default="harvest",
     help="The format of the converted data.",
     show_default=True,
-    type=click.Choice(sorted([to_fmt for sub in CONVERTERS.values() for to_fmt in sub.keys()]), case_sensitive=False),
+    type=click.Choice(
+        sorted([to_fmt for sub in TIME_SERVICES.values() for to_fmt in sub.converters.keys()]), case_sensitive=False
+    ),
 )
 @click.option("--client", help="The name of the client to use in converted data.")
 def convert(

--- a/compiler_admin/commands/time/download.py
+++ b/compiler_admin/commands/time/download.py
@@ -4,7 +4,7 @@ from typing import List
 import click
 from zoneinfo import ZoneInfo
 
-from compiler_admin.services.toggl import TOGGL_COLUMNS, download_time_entries
+from compiler_admin.services.toggl import TogglTime
 
 TZINFO = ZoneInfo("America/Los_Angeles")
 
@@ -98,10 +98,12 @@ def download(
     user_ids: List[int] = [],
 ):
     """Download a Toggl time report in CSV format."""
+    time = TogglTime()
+
     if not output:
         output = f"Toggl_time_entries_{start.strftime('%Y-%m-%d')}_{end.strftime('%Y-%m-%d')}.csv"
 
-    params = dict(start_date=start, end_date=end, output_path=output, output_cols=TOGGL_COLUMNS)
+    params = dict(start_date=start, end_date=end, output_path=output, output_cols=time.TOGGL_COLUMNS)
 
     # By default include billable=True in params.
     # If --all was passed, do not add billable so callers can treat absence as "all".
@@ -120,7 +122,7 @@ def download(
     for k, v in params.items():
         click.echo(f"  {k}: {v}")
 
-    download_time_entries(**params)
+    time.download(**params)
 
     click.echo()
     click.echo(f"Download complete: ./{output}")

--- a/compiler_admin/commands/time/lock.py
+++ b/compiler_admin/commands/time/lock.py
@@ -2,7 +2,7 @@ from datetime import date, datetime, timedelta
 
 import click
 
-from compiler_admin.services.toggl import lock_time_entries
+from compiler_admin.services.toggl import TogglTime
 
 
 @click.command()
@@ -21,5 +21,5 @@ def lock(lock_date_str):
         lock_date = first_day_of_current_month - timedelta(days=1)
 
     click.echo(f"Locking time entries on or before: {lock_date.strftime('%Y-%m-%d')}")
-    lock_time_entries(lock_date)
+    TogglTime().lock(lock_date)
     click.echo("Done.")

--- a/compiler_admin/commands/time/verify.py
+++ b/compiler_admin/commands/time/verify.py
@@ -2,13 +2,13 @@ import sys
 
 import click
 
-from compiler_admin.services import harvest, toggl
+from compiler_admin.services.harvest import HarvestTime
 from compiler_admin.services.time import TimeSummary
-from compiler_admin.services.toggl import normalize_summary
+from compiler_admin.services.toggl import TogglTime
 
 SUMMARIZERS = {
-    "harvest": harvest.summarize,
-    "toggl": toggl.summarize,
+    "harvest": HarvestTime().summarize,
+    "toggl": TogglTime().summarize,
 }
 
 
@@ -85,6 +85,8 @@ def verify(files: list[str]):
             click.echo(f"Error processing file {file_path}: {e}", err=True)
             return
 
+    toggl_time = TogglTime()
+
     if len(summaries) == 1:
         click.echo(f"Summary for: {files[0]}")
         summary: TimeSummary = summaries[0]
@@ -105,9 +107,9 @@ def verify(files: list[str]):
         file2_type = detect_file_type(files[1])
 
         if file1_type == "toggl" and file2_type == "harvest":
-            summary1 = normalize_summary(summary1)
+            summary1 = toggl_time.normalize_summary(summary1)
         elif file1_type == "harvest" and file2_type == "toggl":
-            summary2 = normalize_summary(summary2)
+            summary2 = toggl_time.normalize_summary(summary2)
 
         if summary1 == summary2:
             click.echo("Summaries match.")

--- a/compiler_admin/services/harvest.py
+++ b/compiler_admin/services/harvest.py
@@ -9,125 +9,124 @@ import pandas as pd
 import compiler_admin.services.files as files
 from compiler_admin.services.time import TimeSummary
 
-# input CSV columns needed for conversion
-HARVEST_COLUMNS = ["Date", "Client", "Project", "Notes", "Hours", "First name", "Last name"]
 
-# default output CSV columns
-TOGGL_COLUMNS = ["Email", "Start date", "Start time", "Duration", "Project", "Task", "Client", "Billable", "Description"]
+class HarvestTime:
 
+    # input CSV columns needed for conversion
+    HARVEST_COLUMNS = ["Date", "Client", "Project", "Notes", "Hours", "First name", "Last name"]
 
-def _calc_start_time(group: pd.DataFrame):
-    """Start time is offset by the previous record's duration, with a default of 0 offset for the first record."""
-    group["Start time"] = group["Start time"] + group["Duration"].shift(fill_value=pd.to_timedelta("00:00:00")).cumsum()
-    return group
+    # default output CSV columns
+    TOGGL_COLUMNS = ["Email", "Start date", "Start time", "Duration", "Project", "Task", "Client", "Billable", "Description"]
 
+    def __init__(self):
+        self.converters = {"toggl": self.convert_to_toggl}
 
-def _duration_str(duration: timedelta) -> str:
-    """Use total seconds to convert to a datetime and format as a string e.g. 01:30."""
-    return time.strftime("%H:%M", time.gmtime(duration.total_seconds()))
+    def _calc_start_time(self, group: pd.DataFrame):
+        """Start time is offset by the previous record's duration, with a default of 0 offset for the first record."""
+        group["Start time"] = group["Start time"] + group["Duration"].shift(fill_value=pd.to_timedelta("00:00:00")).cumsum()
+        return group
 
+    def _duration_str(self, duration: timedelta) -> str:
+        """Use total seconds to convert to a datetime and format as a string e.g. 01:30."""
+        return time.strftime("%H:%M", time.gmtime(duration.total_seconds()))
 
-def _toggl_client_name():
-    """Gets the value of the TOGGL_CLIENT_NAME env var."""
-    return os.environ.get("TOGGL_CLIENT_NAME")
+    def _toggl_client_name(self):
+        """Gets the value of the TOGGL_CLIENT_NAME env var."""
+        return os.environ.get("TOGGL_CLIENT_NAME")
 
+    def convert_to_toggl(
+        self,
+        source_path: str | TextIO = sys.stdin,
+        output_path: str | TextIO = sys.stdout,
+        output_cols: list[str] = TOGGL_COLUMNS,
+        client_name: str = None,
+        **kwargs,
+    ):
+        """Convert Harvest formatted entries in source_path to equivalent Toggl formatted entries.
 
-def convert_to_toggl(
-    source_path: str | TextIO = sys.stdin,
-    output_path: str | TextIO = sys.stdout,
-    output_cols: list[str] = TOGGL_COLUMNS,
-    client_name: str = None,
-    **kwargs,
-):
-    """Convert Harvest formatted entries in source_path to equivalent Toggl formatted entries.
+        Args:
+            source_path: The path to a readable CSV file of Harvest time entries; or a readable buffer of the same.
 
-    Args:
-        source_path: The path to a readable CSV file of Harvest time entries; or a readable buffer of the same.
+            output_cols (list[str]): A list of column names for the output
 
-        output_cols (list[str]): A list of column names for the output
+            output_path: The path to a CSV file where Toggl time entries will be written; or a writeable buffer for the same.
 
-        output_path: The path to a CSV file where Toggl time entries will be written; or a writeable buffer for the same.
+        Returns:
+            None. Either prints the resulting CSV data or writes to output_path.
+        """
+        if client_name is None:
+            client_name = self._toggl_client_name()
 
-    Returns:
-        None. Either prints the resulting CSV data or writes to output_path.
-    """
-    if client_name is None:
-        client_name = _toggl_client_name()
+        # read CSV file, parsing dates
+        source = files.read_csv(source_path, usecols=self.HARVEST_COLUMNS, parse_dates=["Date"], cache_dates=True)
 
-    # read CSV file, parsing dates
-    source = files.read_csv(source_path, usecols=HARVEST_COLUMNS, parse_dates=["Date"], cache_dates=True)
+        # rename columns that can be imported as-is
+        source.rename(columns={"Project": "Task", "Notes": "Description", "Date": "Start date"}, inplace=True)
 
-    # rename columns that can be imported as-is
-    source.rename(columns={"Project": "Task", "Notes": "Description", "Date": "Start date"}, inplace=True)
+        # update static calculated columns
+        source["Client"] = client_name
+        source["Project"] = client_name
+        source["Billable"] = "Yes"
 
-    # update static calculated columns
-    source["Client"] = client_name
-    source["Project"] = client_name
-    source["Billable"] = "Yes"
+        # add the Email column
+        source["Email"] = source["First name"].apply(lambda x: f"{x.lower()}@compiler.la")
 
-    # add the Email column
-    source["Email"] = source["First name"].apply(lambda x: f"{x.lower()}@compiler.la")
+        # Convert numeric Hours to timedelta Duration
+        source["Duration"] = source["Hours"].apply(pd.to_timedelta, unit="hours")
 
-    # Convert numeric Hours to timedelta Duration
-    source["Duration"] = source["Hours"].apply(pd.to_timedelta, unit="hours")
+        # Default start time to 09:00
+        source["Start time"] = pd.to_timedelta("09:00:00")
 
-    # Default start time to 09:00
-    source["Start time"] = pd.to_timedelta("09:00:00")
+        user_days = (
+            source
+            # sort and group by email and date
+            .sort_values(["Email", "Start date"]).groupby(["Email", "Start date"], observed=False)
+            # calculate a start time within each group (excluding the groupby columns)
+            .apply(self._calc_start_time, include_groups=False)
+        )
 
-    user_days = (
-        source
-        # sort and group by email and date
-        .sort_values(["Email", "Start date"]).groupby(["Email", "Start date"], observed=False)
-        # calculate a start time within each group (excluding the groupby columns)
-        .apply(_calc_start_time, include_groups=False)
-    )
+        # convert timedeltas to duration strings
+        user_days["Duration"] = user_days["Duration"].apply(self._duration_str)
+        user_days["Start time"] = user_days["Start time"].apply(self._duration_str)
 
-    # convert timedeltas to duration strings
-    user_days["Duration"] = user_days["Duration"].apply(_duration_str)
-    user_days["Start time"] = user_days["Start time"].apply(_duration_str)
+        # re-sort by start date/time and user
+        # reset the index to get rid of the group multi index and fold the group columns back down
+        output_data = pd.DataFrame(data=user_days).reset_index()
+        output_data.sort_values(["Start date", "Start time", "Email"], inplace=True)
 
-    # re-sort by start date/time and user
-    # reset the index to get rid of the group multi index and fold the group columns back down
-    output_data = pd.DataFrame(data=user_days).reset_index()
-    output_data.sort_values(["Start date", "Start time", "Email"], inplace=True)
+        files.write_csv(output_path, output_data, output_cols)
 
-    files.write_csv(output_path, output_data, output_cols)
+    def summarize(self, path: str | TextIO) -> "TimeSummary":
+        """Summarize a Harvest CSV file.
 
+        Args:
+            path (str | TextIO): The path to a readable CSV file of Harvest time entries; or a readable buffer of the same.
 
-def summarize(path: str | TextIO) -> "TimeSummary":
-    """Summarize a Harvest CSV file.
+        Returns:
+            TimeSummary: A summary of the time entries.
+        """
 
-    Args:
-        path (str | TextIO): The path to a readable CSV file of Harvest time entries; or a readable buffer of the same.
+        # read CSV file, parsing dates
+        source = files.read_csv(path, usecols=self.HARVEST_COLUMNS, parse_dates=["Date"], cache_dates=True)
 
-    Returns:
-        TimeSummary: A summary of the time entries.
-    """
+        summary = TimeSummary(
+            earliest_date=source["Date"].min().date(),
+            latest_date=source["Date"].max().date(),
+            total_rows=len(source),
+            total_hours=source["Hours"].sum(),
+        )
 
-    # read CSV file, parsing dates
-    source = files.read_csv(path, usecols=HARVEST_COLUMNS, parse_dates=["Date"], cache_dates=True)
+        # Group by Project to get hours per project
+        project_hours = source.groupby(["Project"])["Hours"].sum().to_dict()
+        summary.hours_per_project = project_hours
 
-    summary = TimeSummary(
-        earliest_date=source["Date"].min().date(),
-        latest_date=source["Date"].max().date(),
-        total_rows=len(source),
-        total_hours=source["Hours"].sum(),
-    )
+        # Group by User and Project to get hours per user/project
+        user_project_hours = source.groupby(["First name", "Last name", "Project"])["Hours"].sum().to_dict()
+        # create a nested dict of the form {user: {project: hours}}
+        for (first, last, project), hours in user_project_hours.items():
+            user = f"{first} {last}"
+            if user not in summary.hours_per_user_project:
+                summary.hours_per_user_project[user] = {}
+            summary.hours_per_user_project[user][project] = hours
 
-    # Group by Project to get hours per project
-    project_hours = source.groupby(["Project"])["Hours"].sum().to_dict()
-    summary.hours_per_project = project_hours
-
-    # Group by User and Project to get hours per user/project
-    user_project_hours = source.groupby(["First name", "Last name", "Project"])["Hours"].sum().to_dict()
-    # create a nested dict of the form {user: {project: hours}}
-    for (first, last, project), hours in user_project_hours.items():
-        user = f"{first} {last}"
-        if user not in summary.hours_per_user_project:
-            summary.hours_per_user_project[user] = {}
-        summary.hours_per_user_project[user][project] = hours
-
-    return summary
-
-
-CONVERTERS = {"toggl": convert_to_toggl}
+        return summary

--- a/compiler_admin/services/toggl.py
+++ b/compiler_admin/services/toggl.py
@@ -8,7 +8,7 @@ from typing import TextIO
 import pandas as pd
 
 import compiler_admin.services.files as files
-from compiler_admin.api.toggl import Toggl
+from compiler_admin.api.toggl import TogglReports, TogglWorkspace
 from compiler_admin.services.google import user_info as google_user_info
 from compiler_admin.services.time import TimeSummary
 
@@ -17,8 +17,8 @@ class TogglService:
     def __init__(self):
         token = os.environ.get("TOGGL_API_TOKEN")
         workspace = os.environ.get("TOGGL_WORKSPACE_ID")
-        organization = os.environ.get("TOGGL_ORGANIZATION_ID", 0)
-        self.api = Toggl(token, workspace, organization)
+        self.reports_api = TogglReports(token, workspace)
+        self.workspace_api = TogglWorkspace(token, workspace)
 
 
 class TogglTime(TogglService):
@@ -221,7 +221,7 @@ class TogglTime(TogglService):
         Returns:
             None. Either prints the resulting CSV data or writes to output_path.
         """
-        response = self.api.detailed_time_entries(start_date, end_date, **kwargs)
+        response = self.reports_api.detailed_time_entries(start_date, end_date, **kwargs)
         # the raw response has these initial 3 bytes:
         #
         #   b"\xef\xbb\xbfUser,Email,Client..."
@@ -244,7 +244,7 @@ class TogglTime(TogglService):
             lock_date (datetime): The date to lock time entries.
         """
         lock_date_str = lock_date.strftime("%Y-%m-%d")
-        self.api.update_workspace_preferences(report_locked_at=lock_date_str)
+        self.workspace_api.update_preferences(report_locked_at=lock_date_str)
 
     def normalize_summary(self, toggl_summary: TimeSummary) -> TimeSummary:
         """Normalize a Toggl TimeSummary to match the Harvest format."""

--- a/compiler_admin/services/toggl.py
+++ b/compiler_admin/services/toggl.py
@@ -13,7 +13,15 @@ from compiler_admin.services.google import user_info as google_user_info
 from compiler_admin.services.time import TimeSummary
 
 
-class TogglTime:
+class TogglService:
+    def __init__(self):
+        token = os.environ.get("TOGGL_API_TOKEN")
+        workspace = os.environ.get("TOGGL_WORKSPACE_ID")
+        organization = os.environ.get("TOGGL_ORGANIZATION_ID", 0)
+        self.api = Toggl(token, workspace, organization)
+
+
+class TogglTime(TogglService):
     # input columns needed for conversion
     TOGGL_COLUMNS = ["Email", "Project", "Task", "Client", "Start date", "Start time", "Duration", "Description"]
 
@@ -23,10 +31,7 @@ class TogglTime:
     JUSTWORKS_COLUMNS = ["First Name", "Last Name", "Work Email", "Start Date", "End Date", "Regular Hours"]
 
     def __init__(self):
-        token = os.environ.get("TOGGL_API_TOKEN")
-        workspace = os.environ.get("TOGGL_WORKSPACE_ID")
-        organization = os.environ.get("TOGGL_ORGANIZATION_ID")
-        self.toggl = Toggl(token, workspace, organization)
+        super().__init__()
         self.converters = {"harvest": self.convert_to_harvest, "justworks": self.convert_to_justworks}
 
     @cache
@@ -216,7 +221,7 @@ class TogglTime:
         Returns:
             None. Either prints the resulting CSV data or writes to output_path.
         """
-        response = self.toggl.detailed_time_entries(start_date, end_date, **kwargs)
+        response = self.api.detailed_time_entries(start_date, end_date, **kwargs)
         # the raw response has these initial 3 bytes:
         #
         #   b"\xef\xbb\xbfUser,Email,Client..."
@@ -239,7 +244,7 @@ class TogglTime:
             lock_date (datetime): The date to lock time entries.
         """
         lock_date_str = lock_date.strftime("%Y-%m-%d")
-        self.toggl.update_workspace_preferences(report_locked_at=lock_date_str)
+        self.api.update_workspace_preferences(report_locked_at=lock_date_str)
 
     def normalize_summary(self, toggl_summary: TimeSummary) -> TimeSummary:
         """Normalize a Toggl TimeSummary to match the Harvest format."""

--- a/compiler_admin/services/toggl.py
+++ b/compiler_admin/services/toggl.py
@@ -12,303 +12,291 @@ from compiler_admin.api.toggl import Toggl
 from compiler_admin.services.google import user_info as google_user_info
 from compiler_admin.services.time import TimeSummary
 
-# input columns needed for conversion
-TOGGL_COLUMNS = ["Email", "Project", "Task", "Client", "Start date", "Start time", "Duration", "Description"]
 
-# default output CSV columns for Harvest
-HARVEST_COLUMNS = ["Date", "Client", "Project", "Task", "Notes", "Hours", "First name", "Last name"]
-# default output CSV columns for Justworks
-JUSTWORKS_COLUMNS = ["First Name", "Last Name", "Work Email", "Start Date", "End Date", "Regular Hours"]
+class TogglTime:
+    # input columns needed for conversion
+    TOGGL_COLUMNS = ["Email", "Project", "Task", "Client", "Start date", "Start time", "Duration", "Description"]
 
+    # default output CSV columns for Harvest
+    HARVEST_COLUMNS = ["Date", "Client", "Project", "Task", "Notes", "Hours", "First name", "Last name"]
+    # default output CSV columns for Justworks
+    JUSTWORKS_COLUMNS = ["First Name", "Last Name", "Work Email", "Start Date", "End Date", "Regular Hours"]
 
-@cache
-def project_info():
-    """Cache of previously seen project information, keyed on Toggl project name."""
-    return files.JsonFileCache("TOGGL_PROJECT_INFO")
+    def __init__(self):
+        token = os.environ.get("TOGGL_API_TOKEN")
+        workspace = os.environ.get("TOGGL_WORKSPACE_ID")
+        organization = os.environ.get("TOGGL_ORGANIZATION_ID")
+        self.toggl = Toggl(token, workspace, organization)
+        self.converters = {"harvest": self.convert_to_harvest, "justworks": self.convert_to_justworks}
 
+    @cache
+    def project_info(self):
+        """Cache of previously seen project information, keyed on Toggl project name."""
+        return files.JsonFileCache("TOGGL_PROJECT_INFO")
 
-@cache
-def user_info():
-    """Cache of previously seen user information, keyed on email."""
-    return files.JsonFileCache("TOGGL_USER_INFO")
+    @cache
+    def user_info(self):
+        """Cache of previously seen user information, keyed on email."""
+        return files.JsonFileCache("TOGGL_USER_INFO")
 
-
-def _get_name(email: str, name_key) -> str:
-    """Get cached name or query from Google."""
-    info = user_info()
-    user = info.get(email)
-    name = user.get(name_key) if user else None
-    if name is None:
-        user = google_user_info(email)
+    def _get_name(self, email: str, name_key) -> str:
+        """Get cached name or query from Google."""
+        info = self.user_info()
+        user = info.get(email)
         name = user.get(name_key) if user else None
-        if email in info:
-            info[email].update(user)
-        else:
-            info[email] = user
-    return name
+        if name is None:
+            user = google_user_info(email)
+            name = user.get(name_key) if user else None
+            if email in info:
+                info[email].update(user)
+            else:
+                info[email] = user
+        return name
 
+    def _get_first_name(self, email: str) -> str:
+        """Get cached last name or query from Google."""
+        return self._get_name(email, "First Name")
 
-def _get_first_name(email: str) -> str:
-    """Get cached last name or query from Google."""
-    return _get_name(email, "First Name")
+    def _get_last_name(self, email: str):
+        """Get cached last name or query from Google."""
+        return self._get_name(email, "Last Name")
 
+    def _prepare_input(self, source_path: str | TextIO, column_renames: dict = {}) -> pd.DataFrame:
+        """Parse and prepare CSV data from `source_path` into an initial `pandas.DataFrame`."""
+        df = files.read_csv(source_path, usecols=self.TOGGL_COLUMNS, parse_dates=["Start date"], cache_dates=True)
 
-def _get_last_name(email: str):
-    """Get cached last name or query from Google."""
-    return _get_name(email, "Last Name")
+        df["Start time"] = df["Start time"].apply(self._str_timedelta)
+        df["Duration"] = df["Duration"].apply(self._str_timedelta)
 
+        # assign First and Last name
+        df["First name"] = df["Email"].apply(self._get_first_name)
+        df["Last name"] = df["Email"].apply(self._get_last_name)
 
-def _prepare_input(source_path: str | TextIO, column_renames: dict = {}) -> pd.DataFrame:
-    """Parse and prepare CSV data from `source_path` into an initial `pandas.DataFrame`."""
-    df = files.read_csv(source_path, usecols=TOGGL_COLUMNS, parse_dates=["Start date"], cache_dates=True)
+        # calculate hours as a decimal from duration timedelta
+        df["Hours"] = (df["Duration"].dt.total_seconds() / 3600).round(2)
 
-    df["Start time"] = df["Start time"].apply(_str_timedelta)
-    df["Duration"] = df["Duration"].apply(_str_timedelta)
+        # if there is a Task column, prepend to the Description column and remove
+        if "Task" in df.columns:
+            df["Description"] = df.apply(
+                lambda row: (f"[{row['Task']}] {row['Description']}" if pd.notna(row["Task"]) else row["Description"]), axis=1
+            )
+            df.drop(columns=["Task"], inplace=True)
 
-    # assign First and Last name
-    df["First name"] = df["Email"].apply(_get_first_name)
-    df["Last name"] = df["Email"].apply(_get_last_name)
+        df.sort_values(["Start date", "Start time", "Email"], inplace=True)
 
-    # calculate hours as a decimal from duration timedelta
-    df["Hours"] = (df["Duration"].dt.total_seconds() / 3600).round(2)
+        if column_renames:
+            df.rename(columns=column_renames, inplace=True)
 
-    # if there is a Task column, prepend to the Description column and remove
-    if "Task" in df.columns:
-        df["Description"] = df.apply(
-            lambda row: (f"[{row['Task']}] {row['Description']}" if pd.notna(row["Task"]) else row["Description"]), axis=1
-        )
-        df.drop(columns=["Task"], inplace=True)
+        return df
 
-    df.sort_values(["Start date", "Start time", "Email"], inplace=True)
+    def _str_timedelta(self, td: str):
+        """Convert a string formatted duration (e.g. 01:30) to a timedelta."""
+        return pd.to_timedelta(pd.to_datetime(td, format="%H:%M:%S").strftime("%H:%M:%S"))
 
-    if column_renames:
-        df.rename(columns=column_renames, inplace=True)
+    def convert_to_harvest(
+        self,
+        source_path: str | TextIO = sys.stdin,
+        output_path: str | TextIO = sys.stdout,
+        output_cols: list[str] = HARVEST_COLUMNS,
+        client_name: str = None,
+        **kwargs,
+    ):
+        """Convert Toggl formatted entries in source_path to equivalent Harvest formatted entries.
 
-    return df
+        Args:
+            source_path: The path to a readable CSV file of Toggl time entries; or a readable buffer of the same.
 
+            output_path: The path to a CSV file where Harvest time entries will be written; or a writeable buffer for the same.
 
-def _str_timedelta(td: str):
-    """Convert a string formatted duration (e.g. 01:30) to a timedelta."""
-    return pd.to_timedelta(pd.to_datetime(td, format="%H:%M:%S").strftime("%H:%M:%S"))
+            output_cols (list[str]): A list of column names for the output
 
+            client_name (str): The value to assign in the output "Client" field
 
-def convert_to_harvest(
-    source_path: str | TextIO = sys.stdin,
-    output_path: str | TextIO = sys.stdout,
-    output_cols: list[str] = HARVEST_COLUMNS,
-    client_name: str = None,
-    **kwargs,
-):
-    """Convert Toggl formatted entries in source_path to equivalent Harvest formatted entries.
+        Returns:
+            None. Either prints the resulting CSV data or writes to output_path.
+        """
+        if client_name is None:
+            client_name = os.environ.get("HARVEST_CLIENT_NAME")
 
-    Args:
-        source_path: The path to a readable CSV file of Toggl time entries; or a readable buffer of the same.
-
-        output_path: The path to a CSV file where Harvest time entries will be written; or a writeable buffer for the same.
-
-        output_cols (list[str]): A list of column names for the output
-
-        client_name (str): The value to assign in the output "Client" field
-
-    Returns:
-        None. Either prints the resulting CSV data or writes to output_path.
-    """
-    if client_name is None:
-        client_name = os.environ.get("HARVEST_CLIENT_NAME")
-
-    source = _prepare_input(
-        source_path=source_path, column_renames={"Project": "Project", "Description": "Notes", "Start date": "Date"}
-    )
-
-    # update static calculated columns
-    source["Client"] = client_name
-    source["Task"] = "Project Consulting"
-
-    # get cached project name if any, keyed on Toggl project name
-    info = project_info()
-    source["Project"] = source["Project"].apply(lambda x: info.get(key=x, default=x))
-
-    # find duplicates based on a subset of columns
-    cols = ["Date", "Hours", "First name", "Last name", "Notes"]
-    is_duplicate = source.duplicated(subset=cols, keep=False)
-
-    if is_duplicate.any():
-        # Create a counter for the duplicate rows
-        counter = source[is_duplicate].groupby(cols).cumcount() + 1
-        group_size = source[is_duplicate].groupby(cols)["Notes"].transform("size")
-
-        # Update the 'Notes' column with the counter
-        source.loc[is_duplicate, "Notes"] = (
-            source.loc[is_duplicate, "Notes"] + " (" + counter.astype(str) + "/" + group_size.astype(str) + ")"
+        source = self._prepare_input(
+            source_path=source_path, column_renames={"Project": "Project", "Description": "Notes", "Start date": "Date"}
         )
 
-    files.write_csv(output_path, source, columns=output_cols)
+        # update static calculated columns
+        source["Client"] = client_name
+        source["Task"] = "Project Consulting"
 
+        # get cached project name if any, keyed on Toggl project name
+        info = self.project_info()
+        source["Project"] = source["Project"].apply(lambda x: info.get(key=x, default=x))
 
-def convert_to_justworks(
-    source_path: str | TextIO = sys.stdin,
-    output_path: str | TextIO = sys.stdout,
-    output_cols: list[str] = JUSTWORKS_COLUMNS,
-    **kwargs,
-):
-    """Convert Toggl formatted entries in source_path to equivalent Justworks formatted entries.
+        # find duplicates based on a subset of columns
+        cols = ["Date", "Hours", "First name", "Last name", "Notes"]
+        is_duplicate = source.duplicated(subset=cols, keep=False)
 
-    Args:
-        source_path: The path to a readable CSV file of Toggl time entries; or a readable buffer of the same.
+        if is_duplicate.any():
+            # Create a counter for the duplicate rows
+            counter = source[is_duplicate].groupby(cols).cumcount() + 1
+            group_size = source[is_duplicate].groupby(cols)["Notes"].transform("size")
 
-        output_path: The path to a CSV file where Harvest time entries will be written; or a writeable buffer for the same.
+            # Update the 'Notes' column with the counter
+            source.loc[is_duplicate, "Notes"] = (
+                source.loc[is_duplicate, "Notes"] + " (" + counter.astype(str) + "/" + group_size.astype(str) + ")"
+            )
 
-        output_cols (list[str]): A list of column names for the output
+        files.write_csv(output_path, source, columns=output_cols)
 
-    Returns:
-        None. Either prints the resulting CSV data or writes to output_path.
-    """
-    source = _prepare_input(
-        source_path=source_path,
-        column_renames={
-            "Email": "Work Email",
-            "First name": "First Name",
-            "Hours": "Regular Hours",
-            "Last name": "Last Name",
-            "Start date": "Start Date",
-        },
-    )
+    def convert_to_justworks(
+        self,
+        source_path: str | TextIO = sys.stdin,
+        output_path: str | TextIO = sys.stdout,
+        output_cols: list[str] = JUSTWORKS_COLUMNS,
+        **kwargs,
+    ):
+        """Convert Toggl formatted entries in source_path to equivalent Justworks formatted entries.
 
-    # aggregate hours per person per day
-    cols = ["Work Email", "First Name", "Last Name", "Start Date"]
-    people = source.sort_values(cols).groupby(cols, observed=False)
-    people_agg = people.agg({"Regular Hours": "sum"})
-    people_agg.reset_index(inplace=True)
+        Args:
+            source_path: The path to a readable CSV file of Toggl time entries; or a readable buffer of the same.
 
-    # aggregate hours per person and rollup to the week (starting on Sunday)
-    cols = ["Work Email", "First Name", "Last Name"]
-    weekly_agg = people_agg.groupby(cols).resample("W", label="left", on="Start Date")
-    weekly_agg = weekly_agg["Regular Hours"].sum().reset_index()
+            output_path: The path to a CSV file where Harvest time entries will be written; or a writeable buffer for the same.
 
-    # calculate the week end date (the following Saturday)
-    weekly_agg["End Date"] = weekly_agg["Start Date"] + pd.Timedelta(days=6)
+            output_cols (list[str]): A list of column names for the output
 
-    files.write_csv(output_path, weekly_agg, columns=output_cols)
+        Returns:
+            None. Either prints the resulting CSV data or writes to output_path.
+        """
+        source = self._prepare_input(
+            source_path=source_path,
+            column_renames={
+                "Email": "Work Email",
+                "First name": "First Name",
+                "Hours": "Regular Hours",
+                "Last name": "Last Name",
+                "Start date": "Start Date",
+            },
+        )
 
+        # aggregate hours per person per day
+        cols = ["Work Email", "First Name", "Last Name", "Start Date"]
+        people = source.sort_values(cols).groupby(cols, observed=False)
+        people_agg = people.agg({"Regular Hours": "sum"})
+        people_agg.reset_index(inplace=True)
 
-def download_time_entries(
-    start_date: datetime,
-    end_date: datetime,
-    output_path: str | TextIO = sys.stdout,
-    output_cols: list[str] | None = TOGGL_COLUMNS,
-    **kwargs,
-):
-    """Download a CSV report from Toggl of detailed time entries for the given date range.
+        # aggregate hours per person and rollup to the week (starting on Sunday)
+        cols = ["Work Email", "First Name", "Last Name"]
+        weekly_agg = people_agg.groupby(cols).resample("W", label="left", on="Start Date")
+        weekly_agg = weekly_agg["Regular Hours"].sum().reset_index()
 
-    Args:
-        start_date (datetime): The beginning of the reporting period.
+        # calculate the week end date (the following Saturday)
+        weekly_agg["End Date"] = weekly_agg["Start Date"] + pd.Timedelta(days=6)
 
-        end_date (str): The end of the reporting period.
+        files.write_csv(output_path, weekly_agg, columns=output_cols)
 
-        output_path: The path to a CSV file where Toggl time entries will be written; or a writeable buffer for the same.
+    def download(
+        self,
+        start_date: datetime,
+        end_date: datetime,
+        output_path: str | TextIO = sys.stdout,
+        output_cols: list[str] | None = TOGGL_COLUMNS,
+        **kwargs,
+    ):
+        """Download a CSV report from Toggl of detailed time entries for the given date range.
 
-        output_cols (list[str]): A list of column names for the output.
+        Args:
+            start_date (datetime): The beginning of the reporting period.
 
-    Extra kwargs are passed along in the POST request body.
+            end_date (str): The end of the reporting period.
 
-    Returns:
-        None. Either prints the resulting CSV data or writes to output_path.
-    """
-    token = os.environ.get("TOGGL_API_TOKEN")
-    workspace = os.environ.get("TOGGL_WORKSPACE_ID")
-    toggl = Toggl(token, workspace)
+            output_path: The path to a CSV file where Toggl time entries will be written; or a writeable buffer for the same.
 
-    response = toggl.detailed_time_entries(start_date, end_date, **kwargs)
-    # the raw response has these initial 3 bytes:
-    #
-    #   b"\xef\xbb\xbfUser,Email,Client..."
-    #
-    # \xef\xbb\xb is the Byte Order Mark (BOM) sometimes used in unicode text files
-    # these 3 bytes indicate a utf-8 encoded text file
-    #
-    # See more
-    #  - https://en.wikipedia.org/wiki/Byte_order_mark
-    #  - https://stackoverflow.com/a/50131187
-    csv = response.content.decode("utf-8-sig")
+            output_cols (list[str]): A list of column names for the output.
 
-    df = pd.read_csv(io.StringIO(csv))
-    files.write_csv(output_path, df, columns=output_cols)
+        Extra kwargs are passed along in the POST request body.
 
+        Returns:
+            None. Either prints the resulting CSV data or writes to output_path.
+        """
+        response = self.toggl.detailed_time_entries(start_date, end_date, **kwargs)
+        # the raw response has these initial 3 bytes:
+        #
+        #   b"\xef\xbb\xbfUser,Email,Client..."
+        #
+        # \xef\xbb\xb is the Byte Order Mark (BOM) sometimes used in unicode text files
+        # these 3 bytes indicate a utf-8 encoded text file
+        #
+        # See more
+        #  - https://en.wikipedia.org/wiki/Byte_order_mark
+        #  - https://stackoverflow.com/a/50131187
+        csv = response.content.decode("utf-8-sig")
 
-def lock_time_entries(lock_date: datetime):
-    """Lock time entries on the given date.
+        df = pd.read_csv(io.StringIO(csv))
+        files.write_csv(output_path, df, columns=output_cols)
 
-    Args:
-        lock_date (datetime): The date to lock time entries.
-    """
-    token = os.environ.get("TOGGL_API_TOKEN")
-    workspace = os.environ.get("TOGGL_WORKSPACE_ID")
-    toggl = Toggl(token, workspace)
+    def lock(self, lock_date: datetime):
+        """Lock time entries on the given date in the Toggl workspace.
 
-    lock_date_str = lock_date.strftime("%Y-%m-%d")
-    toggl.update_workspace_preferences(report_locked_at=lock_date_str)
+        Args:
+            lock_date (datetime): The date to lock time entries.
+        """
+        lock_date_str = lock_date.strftime("%Y-%m-%d")
+        self.toggl.update_workspace_preferences(report_locked_at=lock_date_str)
 
+    def normalize_summary(self, toggl_summary: TimeSummary) -> TimeSummary:
+        """Normalize a Toggl TimeSummary to match the Harvest format."""
+        info = self.project_info()
+        new_summary = TimeSummary(
+            earliest_date=toggl_summary.earliest_date,
+            latest_date=toggl_summary.latest_date,
+            total_rows=toggl_summary.total_rows,
+            total_hours=toggl_summary.total_hours,
+        )
 
-def normalize_summary(toggl_summary: TimeSummary) -> TimeSummary:
-    """Normalize a Toggl TimeSummary to match the Harvest format."""
-    info = project_info()
-    new_summary = TimeSummary(
-        earliest_date=toggl_summary.earliest_date,
-        latest_date=toggl_summary.latest_date,
-        total_rows=toggl_summary.total_rows,
-        total_hours=toggl_summary.total_hours,
-    )
-
-    for project, hours in toggl_summary.hours_per_project.items():
-        harvest_project = info.get(key=project, default=project)
-        new_summary.hours_per_project[harvest_project] = hours
-
-    for email, projects in toggl_summary.hours_per_user_project.items():
-        first_name = _get_first_name(email)
-        last_name = _get_last_name(email)
-        user = f"{first_name} {last_name}"
-        new_summary.hours_per_user_project[user] = {}
-        for project, hours in projects.items():
+        for project, hours in toggl_summary.hours_per_project.items():
             harvest_project = info.get(key=project, default=project)
-            new_summary.hours_per_user_project[user][harvest_project] = hours
+            new_summary.hours_per_project[harvest_project] = hours
 
-    return new_summary
+        for email, projects in toggl_summary.hours_per_user_project.items():
+            first_name = self._get_first_name(email)
+            last_name = self._get_last_name(email)
+            user = f"{first_name} {last_name}"
+            new_summary.hours_per_user_project[user] = {}
+            for project, hours in projects.items():
+                harvest_project = info.get(key=project, default=project)
+                new_summary.hours_per_user_project[user][harvest_project] = hours
 
+        return new_summary
 
-def summarize(path: str | TextIO) -> TimeSummary:
-    """Summarize a Toggl CSV file.
+    def summarize(self, path: str | TextIO) -> TimeSummary:
+        """Summarize a Toggl CSV file.
 
-    Args:
-        path (str | TextIO): The path to a readable CSV file of Toggl time entries; or a readable buffer of the same.
+        Args:
+            path (str | TextIO): The path to a readable CSV file of Toggl time entries; or a readable buffer of the same.
 
-    Returns:
-        TimeSummary: A summary of the time entries.
-    """
-    source = files.read_csv(path, usecols=TOGGL_COLUMNS, parse_dates=["Start date"], cache_dates=True)
+        Returns:
+            TimeSummary: A summary of the time entries.
+        """
+        source = files.read_csv(path, usecols=self.TOGGL_COLUMNS, parse_dates=["Start date"], cache_dates=True)
 
-    # calculate hours as a decimal from duration string
-    source["Hours"] = (pd.to_timedelta(source["Duration"]).dt.total_seconds() / 3600).round(2)
+        # calculate hours as a decimal from duration string
+        source["Hours"] = (pd.to_timedelta(source["Duration"]).dt.total_seconds() / 3600).round(2)
 
-    summary = TimeSummary(
-        earliest_date=source["Start date"].min().date(),
-        latest_date=source["Start date"].max().date(),
-        total_rows=len(source),
-        total_hours=source["Hours"].sum(),
-    )
+        summary = TimeSummary(
+            earliest_date=source["Start date"].min().date(),
+            latest_date=source["Start date"].max().date(),
+            total_rows=len(source),
+            total_hours=source["Hours"].sum(),
+        )
 
-    # Group by Project to get hours per project
-    project_hours = source.groupby(["Project"])["Hours"].sum().to_dict()
-    summary.hours_per_project = project_hours
+        # Group by Project to get hours per project
+        project_hours = source.groupby(["Project"])["Hours"].sum().to_dict()
+        summary.hours_per_project = project_hours
 
-    # Group by User and Project to get hours per user/project
-    user_project_hours = source.groupby(["Email", "Project"])["Hours"].sum().to_dict()
-    # create a nested dict of the form {user: {project: hours}}
-    for (email, project), hours in user_project_hours.items():
-        if email not in summary.hours_per_user_project:
-            summary.hours_per_user_project[email] = {}
-        summary.hours_per_user_project[email][project] = hours
+        # Group by User and Project to get hours per user/project
+        user_project_hours = source.groupby(["Email", "Project"])["Hours"].sum().to_dict()
+        # create a nested dict of the form {user: {project: hours}}
+        for (email, project), hours in user_project_hours.items():
+            if email not in summary.hours_per_user_project:
+                summary.hours_per_user_project[email] = {}
+            summary.hours_per_user_project[email][project] = hours
 
-    return summary
-
-
-CONVERTERS = {"harvest": convert_to_harvest, "justworks": convert_to_justworks}
+        return summary

--- a/notebooks/download-and-convert.ipynb
+++ b/notebooks/download-and-convert.ipynb
@@ -8,7 +8,7 @@
       "source": [
         "from datetime import datetime\n",
         "\n",
-        "from compiler_admin.services.toggl import download_time_entries, convert_to_harvest"
+        "from compiler_admin.services.toggl import TogglTime"
       ]
     },
     {
@@ -18,7 +18,8 @@
       "outputs": [],
       "source": [
         "start = datetime(2024, 9, 1)\n",
-        "end = datetime(2024, 9, 24)"
+        "end = datetime(2024, 9, 24)\n",
+        "time = TogglTime()"
       ]
     },
     {
@@ -27,7 +28,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "download_time_entries(start, end, \"data/time_entries.csv\")"
+        "time.download(start, end, \"data/time_entries.csv\")"
       ]
     },
     {
@@ -36,7 +37,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "convert_to_harvest(\"data/time_entries.csv\", \"data/time_entries_harvest.csv\")"
+        "time.convert_to_harvest(\"data/time_entries.csv\", \"data/time_entries_harvest.csv\")"
       ]
     }
   ],

--- a/tests/api/test_toggl.py
+++ b/tests/api/test_toggl.py
@@ -4,8 +4,7 @@ from pathlib import Path
 import pytest
 
 from compiler_admin import __version__
-from compiler_admin.api.toggl import Toggl
-from compiler_admin.api.toggl import __name__ as MODULE
+from compiler_admin.api.toggl import __name__ as MODULE, TogglBase, TogglReports, TogglWorkspace
 
 
 @pytest.fixture
@@ -13,101 +12,120 @@ def mock_requests(mocker):
     return mocker.patch(f"{MODULE}.requests.Session").return_value
 
 
-@pytest.fixture
-def toggl():
-    return Toggl("token", 1234)
+class TestTogglBase:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.toggl = TogglBase("token", 1234)
+
+    def test_init(self):
+        assert self.toggl.workspace_id == 1234
+
+        token64 = "dG9rZW46YXBpX3Rva2Vu"
+        assert self.toggl._token == "token"
+        assert self.toggl.headers["Authorization"] == f"Basic {token64}"
+
+        assert self.toggl.headers["Content-Type"] == "application/json"
+
+        user_agent = self.toggl.headers["User-Agent"]
+        assert "compilerla/compiler-admin" in user_agent
+        assert __version__ in user_agent
+
+        assert self.toggl.timeout == 5
+
+    def test_api_url_resource(self):
+        with pytest.raises(NotImplementedError):
+            assert self.toggl.api_url_resource
+
+    def test_api_url_version(self):
+        assert self.toggl.api_url_version == self.toggl.API_VERSION
+
+    def test_make_api_url(self):
+        class TogglTest(TogglBase):
+            @property
+            def api_url_resource(self):
+                return "resource"
+
+        self.toggl = TogglTest(self.toggl._token, self.toggl.workspace_id)
+
+        url = self.toggl.make_api_url("endpoint")
+
+        assert url.startswith(self.toggl.API_BASE_URL)
+        assert self.toggl.api_url_version in url
+        assert self.toggl.api_url_resource in url
+        assert "/endpoint" in url
 
 
-@pytest.fixture
-def toggl_mock_post_reports(mocker, toggl, toggl_file):
-    # setup a mock response to a requests.post call
-    mock_csv_bytes = Path(toggl_file).read_bytes()
-    mock_post_response = mocker.Mock()
-    mock_post_response.raise_for_status.return_value = None
-    # prepend the BOM to the mock content
-    mock_post_response.content = b"\xef\xbb\xbf" + mock_csv_bytes
-    # override the requests.post call to return the mock response
-    mocker.patch.object(toggl, "post_reports", return_value=mock_post_response)
-    return toggl
+class TestTogglReports:
+    @pytest.fixture(autouse=True)
+    def setup(self, mock_requests):
+        self.toggl = TogglReports("token", 1234)
+
+    @pytest.fixture
+    def toggl_mock_post_reports(self, mocker, toggl_file):
+        # setup a mock response to a requests.post call
+        mock_csv_bytes = Path(toggl_file).read_bytes()
+        mock_post_response = mocker.Mock()
+        mock_post_response.raise_for_status.return_value = None
+        # prepend the BOM to the mock content
+        mock_post_response.content = b"\xef\xbb\xbf" + mock_csv_bytes
+        # override the requests.post call to return the mock response
+        mocker.patch.object(self.toggl, "post_reports", return_value=mock_post_response)
+        return self.toggl
+
+    def test_api_url_resource(self):
+        assert self.toggl.api_url_resource == "workspace/1234"
+
+    def test_api_url_version(self):
+        assert self.toggl.api_url_version == self.toggl.REPORTS_API_VERSION
+
+    def test_toggl_post_reports(self, mock_requests):
+        url = self.toggl.make_api_url("endpoint")
+        response = self.toggl.post_reports("endpoint", kwarg1=1, kwarg2="two")
+
+        response.raise_for_status.assert_called_once()
+
+        mock_requests.post.assert_called_once_with(url, json=dict(kwarg1=1, kwarg2="two"), timeout=self.toggl.timeout)
+
+    def test_toggl_detailed_time_entries(self, toggl_mock_post_reports):
+        dt = datetime(2024, 9, 25)
+        toggl_mock_post_reports.detailed_time_entries(dt, dt, kwarg1=1, kwarg2="two")
+
+        toggl_mock_post_reports.post_reports.assert_called_once_with(
+            "search/time_entries.csv",
+            start_date="2024-09-25",
+            end_date="2024-09-25",
+            rounding=1,
+            rounding_minutes=15,
+            kwarg1=1,
+            kwarg2="two",
+        )
+
+    def test_toggl_detailed_time_entries_dynamic_timeout(self, mock_requests):
+        # range of 6 months
+        # timeout should be 6 * 5 = 30
+        start = datetime(2024, 1, 1)
+        end = datetime(2024, 6, 30)
+        self.toggl.detailed_time_entries(start, end)
+
+        mock_requests.post.assert_called_once()
+        assert mock_requests.post.call_args.kwargs["timeout"] == 30
 
 
-def test_toggl_init(toggl):
-    token64 = "dG9rZW46YXBpX3Rva2Vu"
+class TestTogglWorkspace:
+    @pytest.fixture(autouse=True)
+    def setup(self, mock_requests):
+        self.toggl = TogglWorkspace("token", 1234)
 
-    assert toggl._token == "token"
-    assert toggl.workspace_id == 1234
-    assert toggl.workspace_url_fragment == "workspace/1234"
+    def test_api_url_resource(self):
+        assert self.toggl.api_url_resource == "workspaces/1234"
 
-    assert toggl.headers["Content-Type"] == "application/json"
+    def test_update_preferences(self, mocker, mock_requests):
+        url = "http://fake.url"
+        mocker.patch.object(self.toggl, "make_api_url", return_value=url)
+        prefs = {"pref1": "value1", "pref2": True}
 
-    user_agent = toggl.headers["User-Agent"]
-    assert "compilerla/compiler-admin" in user_agent
-    assert __version__ in user_agent
+        response = self.toggl.update_preferences(**prefs)
 
-    assert toggl.headers["Authorization"] == f"Basic {token64}"
-
-    assert toggl.timeout == 5
-
-
-def test_toggl_make_api_url(toggl):
-    url = toggl._make_api_url("endpoint")
-
-    assert url.startswith(toggl.API_BASE_URL)
-    assert toggl.API_VERSION_URL in url
-    assert toggl.workspaces_url_fragment in url
-    assert "/endpoint" in url
-
-
-def test_toggl_make_report_url(toggl):
-    url = toggl._make_report_url("endpoint")
-
-    assert url.startswith(toggl.API_BASE_URL)
-    assert toggl.API_REPORTS_BASE_URL in url
-    assert toggl.workspace_url_fragment in url
-    assert "/endpoint" in url
-
-
-def test_toggl_post_reports(mock_requests, toggl):
-    url = toggl._make_report_url("endpoint")
-    response = toggl.post_reports("endpoint", kwarg1=1, kwarg2="two")
-
-    response.raise_for_status.assert_called_once()
-
-    mock_requests.post.assert_called_once_with(url, json=dict(kwarg1=1, kwarg2="two"), timeout=toggl.timeout)
-
-
-def test_toggl_detailed_time_entries(toggl_mock_post_reports):
-    dt = datetime(2024, 9, 25)
-    toggl_mock_post_reports.detailed_time_entries(dt, dt, kwarg1=1, kwarg2="two")
-
-    toggl_mock_post_reports.post_reports.assert_called_once_with(
-        "search/time_entries.csv",
-        start_date="2024-09-25",
-        end_date="2024-09-25",
-        rounding=1,
-        rounding_minutes=15,
-        kwarg1=1,
-        kwarg2="two",
-    )
-
-
-def test_toggl_detailed_time_entries_dynamic_timeout(mock_requests, toggl):
-    # range of 6 months
-    # timeout should be 6 * 5 = 30
-    start = datetime(2024, 1, 1)
-    end = datetime(2024, 6, 30)
-    toggl.detailed_time_entries(start, end)
-
-    mock_requests.post.assert_called_once()
-    assert mock_requests.post.call_args.kwargs["timeout"] == 30
-
-
-def test_toggl_update_workspace_preferences(mock_requests, toggl, mocker):
-    url = "http://fake.url"
-    mocker.patch.object(toggl, "_make_api_url", return_value=url)
-    prefs = {"pref1": "value1", "pref2": True}
-    response = toggl.update_workspace_preferences(**prefs)
-
-    response.raise_for_status.assert_called_once()
-    toggl._make_api_url.assert_called_once_with("preferences")
-    mock_requests.post.assert_called_once_with(url, json=prefs, timeout=toggl.timeout)
+        response.raise_for_status.assert_called_once()
+        self.toggl.make_api_url.assert_called_once_with("preferences")
+        mock_requests.post.assert_called_once_with(url, json=prefs, timeout=self.toggl.timeout)

--- a/tests/commands/time/test_convert.py
+++ b/tests/commands/time/test_convert.py
@@ -1,11 +1,9 @@
 import pytest
 
 from compiler_admin import RESULT_SUCCESS
-from compiler_admin.commands.time.convert import CONVERTERS
-from compiler_admin.commands.time.convert import __name__ as MODULE
-from compiler_admin.commands.time.convert import _get_source_converter, convert
-from compiler_admin.services.harvest import CONVERTERS as HARVEST_CONVERTERS
-from compiler_admin.services.toggl import CONVERTERS as TOGGL_CONVERTERS
+from compiler_admin.commands.time.convert import __name__ as MODULE, TIME_SERVICES, _get_source_converter, convert
+from compiler_admin.services.harvest import HarvestTime
+from compiler_admin.services.toggl import TogglTime
 
 
 @pytest.fixture
@@ -14,12 +12,12 @@ def mock_get_source_converter(mocker):
 
 
 @pytest.fixture
-def mock_converters(mocker):
-    return mocker.patch(f"{MODULE}.CONVERTERS", new={})
+def mock_time_services(mocker):
+    return mocker.patch(f"{MODULE}.TIME_SERVICES", new={})
 
 
-def test_get_source_converter_match(mock_converters):
-    mock_converters["toggl"] = {"test_fmt": "converter"}
+def test_get_source_converter_match(mocker, mock_time_services):
+    mock_time_services["toggl"] = mocker.Mock(converters={"test_fmt": "converter"})
     result = _get_source_converter("toggl", "test_fmt")
 
     assert result == "converter"
@@ -48,6 +46,6 @@ def test_convert(cli_runner, mock_get_source_converter):
     )
 
 
-def test_converters():
-    assert CONVERTERS.get("harvest") == HARVEST_CONVERTERS
-    assert CONVERTERS.get("toggl") == TOGGL_CONVERTERS
+@pytest.mark.parametrize("service,service_type", (("harvest", HarvestTime), ("toggl", TogglTime)))
+def test_services(service, service_type):
+    assert isinstance(TIME_SERVICES.get(service), service_type)

--- a/tests/commands/time/test_download.py
+++ b/tests/commands/time/test_download.py
@@ -3,9 +3,8 @@ from datetime import datetime
 import pytest
 
 from compiler_admin import RESULT_SUCCESS
-from compiler_admin.commands.time.download import TOGGL_COLUMNS, TZINFO
-from compiler_admin.commands.time.download import __name__ as MODULE
-from compiler_admin.commands.time.download import download, prior_month_end, prior_month_start
+from compiler_admin.commands.time.download import __name__ as MODULE, TZINFO, download, prior_month_end, prior_month_start
+from compiler_admin.services.toggl import TogglTime
 
 
 @pytest.fixture
@@ -16,8 +15,8 @@ def mock_local_now(mocker):
 
 
 @pytest.fixture
-def mock_download_time_entries(mocker):
-    return mocker.patch(f"{MODULE}.download_time_entries")
+def mock_time_download(mocker):
+    return mocker.patch.object(TogglTime, "download")
 
 
 def test_prior_month_start(mock_local_now):
@@ -38,7 +37,7 @@ def test_prior_month_end(mock_local_now):
     assert end.tzinfo == TZINFO
 
 
-def test_download(cli_runner, mock_local_now, mock_download_time_entries):
+def test_download(cli_runner, mock_local_now, mock_time_download):
     args = [
         "--start",
         mock_local_now.strftime("%Y-%m-%d"),
@@ -67,12 +66,12 @@ def test_download(cli_runner, mock_local_now, mock_download_time_entries):
     result = cli_runner.invoke(download, args)
 
     assert result.exit_code == RESULT_SUCCESS
-    mock_download_time_entries.assert_called_once_with(
+    mock_time_download.assert_called_once_with(
         start_date=mock_local_now,
         end_date=mock_local_now,
         output_path="output",
         billable=True,
-        output_cols=TOGGL_COLUMNS,
+        output_cols=TogglTime.TOGGL_COLUMNS,
         client_ids=(1, 2),
         project_ids=(3, 4),
         task_ids=(5, 6),
@@ -80,14 +79,14 @@ def test_download(cli_runner, mock_local_now, mock_download_time_entries):
     )
 
 
-def test_download_default(cli_runner, mock_download_time_entries):
+def test_download_default(cli_runner, mock_time_download):
     expected_start, expected_end = prior_month_start(), prior_month_end()
 
     result = cli_runner.invoke(download, [])
 
     assert result.exit_code == RESULT_SUCCESS
-    mock_download_time_entries.assert_called_once()
-    call = mock_download_time_entries.mock_calls[0]
+    mock_time_download.assert_called_once()
+    call = mock_time_download.mock_calls[0]
 
     actual_start = call.kwargs["start_date"]
     assert actual_start.year == expected_start.year
@@ -103,25 +102,25 @@ def test_download_default(cli_runner, mock_download_time_entries):
         call.kwargs["output_path"]
         == f"Toggl_time_entries_{expected_start.strftime('%Y-%m-%d')}_{expected_end.strftime('%Y-%m-%d')}.csv"
     )
-    assert call.kwargs["output_cols"] == TOGGL_COLUMNS
+    assert call.kwargs["output_cols"] == TogglTime.TOGGL_COLUMNS
     assert call.kwargs["billable"] is True
 
 
-def test_download_client_envvar(cli_runner, monkeypatch, mock_download_time_entries):
+def test_download_client_envvar(cli_runner, monkeypatch, mock_time_download):
     monkeypatch.setenv("TOGGL_CLIENT_ID", "1234")
 
     result = cli_runner.invoke(download, [])
 
     assert result.exit_code == RESULT_SUCCESS
-    mock_download_time_entries.assert_called_once()
-    call = mock_download_time_entries.mock_calls[0]
+    mock_time_download.assert_called_once()
+    call = mock_time_download.mock_calls[0]
     assert call.kwargs["client_ids"] == (1234,)
 
 
-def test_download_all(cli_runner, mock_download_time_entries):
+def test_download_all(cli_runner, mock_time_download):
     result = cli_runner.invoke(download, ["--all"])
 
     assert result.exit_code == RESULT_SUCCESS
-    mock_download_time_entries.assert_called_once()
-    call = mock_download_time_entries.mock_calls[0]
+    mock_time_download.assert_called_once()
+    call = mock_time_download.mock_calls[0]
     assert "billable" not in call.kwargs

--- a/tests/commands/time/test_lock.py
+++ b/tests/commands/time/test_lock.py
@@ -4,12 +4,12 @@ import pytest
 from click.testing import CliRunner
 
 from compiler_admin import RESULT_SUCCESS
-from compiler_admin.commands.time.lock import lock, __name__ as MODULE
+from compiler_admin.commands.time.lock import lock, TogglTime
 
 
 @pytest.fixture
 def mock_lock_time_entries(mocker):
-    return mocker.patch(f"{MODULE}.lock_time_entries")
+    return mocker.patch.object(TogglTime, "lock")
 
 
 def test_lock_default_date(mock_lock_time_entries):

--- a/tests/services/test_harvest.py
+++ b/tests/services/test_harvest.py
@@ -8,18 +8,7 @@ import pandas as pd
 import pytest
 
 import compiler_admin.services.harvest
-from compiler_admin.services.harvest import (
-    __name__ as MODULE,
-    files,
-    HARVEST_COLUMNS,
-    TOGGL_COLUMNS,
-    CONVERTERS,
-    _calc_start_time,
-    _duration_str,
-    _toggl_client_name,
-    convert_to_toggl,
-    summarize,
-)
+from compiler_admin.services.harvest import files, HarvestTime
 
 
 @pytest.fixture(autouse=True)
@@ -34,97 +23,98 @@ def spy_files(mocker):
 
 @pytest.fixture
 def mock_toggl_client_name(mocker):
-    return mocker.patch(f"{MODULE}._toggl_client_name")
+    return mocker.patch.object(HarvestTime, "_toggl_client_name")
 
 
-def test_calc_start_time():
-    durations = pd.to_timedelta(np.arange(1, 6), unit="m")
-    df = pd.DataFrame(data={"Duration": durations, "Start time": [pd.to_timedelta("09:00:00") for d in durations]})
+class TestHarvestTime:
 
-    calc_df = _calc_start_time(df)
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.time = HarvestTime()
 
-    assert calc_df.columns.equals(df.columns)
-    assert calc_df["Duration"].equals(df["Duration"])
-    assert calc_df["Start time"].to_list() == [
-        # offset = 0, cumsum = 0
-        pd.to_timedelta("09:00:00"),
-        # offset = 1, cumsum = 1
-        pd.to_timedelta("09:01:00"),
-        # offset = 2, cumsum = 3
-        pd.to_timedelta("09:03:00"),
-        # offset = 3, cumsum = 6
-        pd.to_timedelta("09:06:00"),
-        # offset = 4, cumsum = 10
-        pd.to_timedelta("09:10:00"),
-    ]
+    def test_calc_start_time(self):
+        durations = pd.to_timedelta(np.arange(1, 6), unit="m")
+        df = pd.DataFrame(data={"Duration": durations, "Start time": [pd.to_timedelta("09:00:00") for d in durations]})
 
+        calc_df = self.time._calc_start_time(df)
 
-def test_converters():
-    assert CONVERTERS.get("toggl") == convert_to_toggl
+        assert calc_df.columns.equals(df.columns)
+        assert calc_df["Duration"].equals(df["Duration"])
+        assert calc_df["Start time"].to_list() == [
+            # offset = 0, cumsum = 0
+            pd.to_timedelta("09:00:00"),
+            # offset = 1, cumsum = 1
+            pd.to_timedelta("09:01:00"),
+            # offset = 2, cumsum = 3
+            pd.to_timedelta("09:03:00"),
+            # offset = 3, cumsum = 6
+            pd.to_timedelta("09:06:00"),
+            # offset = 4, cumsum = 10
+            pd.to_timedelta("09:10:00"),
+        ]
 
+    def test_converters(self):
+        assert self.time.converters.get("toggl") == self.time.convert_to_toggl
+        assert self.time.converters.get("nope") is None
 
-def test_convert_to_toggl_mocked(harvest_file, spy_files, mock_toggl_client_name):
-    convert_to_toggl(harvest_file, client_name=None)
+    def test_convert_to_toggl_mocked(self, harvest_file, spy_files, mock_toggl_client_name):
+        self.time.convert_to_toggl(harvest_file, client_name=None)
 
-    mock_toggl_client_name.assert_called_once()
+        mock_toggl_client_name.assert_called_once()
 
-    spy_files.read_csv.assert_called_once()
-    call_args = spy_files.read_csv.call_args
-    assert (harvest_file,) in call_args
-    assert call_args.kwargs["usecols"] == HARVEST_COLUMNS
-    assert call_args.kwargs["parse_dates"] == ["Date"]
-    assert call_args.kwargs["cache_dates"] is True
+        spy_files.read_csv.assert_called_once()
+        call_args = spy_files.read_csv.call_args
+        assert (harvest_file,) in call_args
+        assert call_args.kwargs["usecols"] == self.time.HARVEST_COLUMNS
+        assert call_args.kwargs["parse_dates"] == ["Date"]
+        assert call_args.kwargs["cache_dates"] is True
 
-    spy_files.write_csv.assert_called_once()
-    call_args = spy_files.write_csv.call_args
-    assert call_args[0][0] == sys.stdout
-    assert call_args[0][2] == TOGGL_COLUMNS
+        spy_files.write_csv.assert_called_once()
+        call_args = spy_files.write_csv.call_args
+        assert call_args[0][0] == sys.stdout
+        assert call_args[0][2] == self.time.TOGGL_COLUMNS
 
+    def test_convert_to_toggl_sample(self, harvest_file, toggl_file):
+        output = None
 
-def test_convert_to_toggl_sample(harvest_file, toggl_file):
-    output = None
+        with StringIO() as output_data:
+            self.time.convert_to_toggl(harvest_file, output_data, client_name="Test Client 123")
+            output = output_data.getvalue()
 
-    with StringIO() as output_data:
-        convert_to_toggl(harvest_file, output_data, client_name="Test Client 123")
-        output = output_data.getvalue()
+        assert output
+        assert isinstance(output, str)
+        assert ",".join(self.time.TOGGL_COLUMNS) in output
 
-    assert output
-    assert isinstance(output, str)
-    assert ",".join(TOGGL_COLUMNS) in output
+        order = ["Start date", "Start time", "Email"]
+        sample_output_df = pd.read_csv(toggl_file).sort_values(order)
+        output_df = pd.read_csv(StringIO(output)).sort_values(order)
 
-    order = ["Start date", "Start time", "Email"]
-    sample_output_df = pd.read_csv(toggl_file).sort_values(order)
-    output_df = pd.read_csv(StringIO(output)).sort_values(order)
+        assert set(output_df.columns.to_list()) <= set(sample_output_df.columns.to_list())
+        assert output_df["Client"].eq("Test Client 123").all()
+        assert output_df["Project"].eq("Test Client 123").all()
 
-    assert set(output_df.columns.to_list()) <= set(sample_output_df.columns.to_list())
-    assert output_df["Client"].eq("Test Client 123").all()
-    assert output_df["Project"].eq("Test Client 123").all()
+    def test_duration_str(self):
+        td = timedelta(hours=1, minutes=30, seconds=15)
 
+        result = self.time._duration_str(td)
 
-def test_duration_str():
-    td = timedelta(hours=1, minutes=30, seconds=15)
+        assert isinstance(result, str)
+        assert result == "01:30"
 
-    result = _duration_str(td)
+    def test_summarize(self, harvest_file):
+        """Test that summarize returns a valid TimeSummary object."""
+        summary = self.time.summarize(harvest_file)
 
-    assert isinstance(result, str)
-    assert result == "01:30"
+        assert summary.earliest_date == date(2023, 1, 2)
+        assert summary.latest_date == date(2023, 1, 30)
+        assert summary.total_rows == 250
+        assert math.isclose(summary.total_hours, 518.32, rel_tol=1e-5)
+        assert len(summary.hours_per_project) > 0
+        assert len(summary.hours_per_user_project) > 0
 
+    def test_toggl_client_name(self, monkeypatch):
+        assert self.time._toggl_client_name() == "Test_Client"
 
-def test_summarize(harvest_file):
-    """Test that summarize returns a valid TimeSummary object."""
-    summary = summarize(harvest_file)
+        monkeypatch.setenv("TOGGL_CLIENT_NAME", "New Test Client")
 
-    assert summary.earliest_date == date(2023, 1, 2)
-    assert summary.latest_date == date(2023, 1, 30)
-    assert summary.total_rows == 250
-    assert math.isclose(summary.total_hours, 518.32, rel_tol=1e-5)
-    assert len(summary.hours_per_project) > 0
-    assert len(summary.hours_per_user_project) > 0
-
-
-def test_toggl_client_name(monkeypatch):
-    assert _toggl_client_name() == "Test_Client"
-
-    monkeypatch.setenv("TOGGL_CLIENT_NAME", "New Test Client")
-
-    assert _toggl_client_name() == "New Test Client"
+        assert self.time._toggl_client_name() == "New Test Client"

--- a/tests/services/test_toggl.py
+++ b/tests/services/test_toggl.py
@@ -9,20 +9,7 @@ import pandas as pd
 import pytest
 
 import compiler_admin.services.toggl
-from compiler_admin.services.toggl import CONVERTERS, HARVEST_COLUMNS, JUSTWORKS_COLUMNS, TOGGL_COLUMNS
-from compiler_admin.services.toggl import __name__ as MODULE
-from compiler_admin.services.toggl import (
-    _get_first_name,
-    _get_last_name,
-    _prepare_input,
-    _str_timedelta,
-    convert_to_harvest,
-    convert_to_justworks,
-    download_time_entries,
-    files,
-    lock_time_entries,
-    summarize,
-)
+from compiler_admin.services.toggl import __name__ as MODULE, TogglTime, files
 
 
 @pytest.fixture(autouse=True)
@@ -39,18 +26,12 @@ def spy_files(mocker):
 
 @pytest.fixture()
 def mock_user_info(mocker):
-    return mocker.patch(f"{MODULE}.user_info")
+    return mocker.patch.object(TogglTime, "user_info")
 
 
 @pytest.fixture
 def mock_google_user_info(mocker):
     return mocker.patch(f"{MODULE}.google_user_info")
-
-
-@pytest.fixture
-def mock_toggl_api(mocker):
-    t = mocker.patch(f"{MODULE}.Toggl")
-    return t.return_value
 
 
 @pytest.fixture
@@ -60,245 +41,236 @@ def mock_toggl_api_env(monkeypatch):
     monkeypatch.setenv("TOGGL_WORKSPACE_ID", "workspace")
 
 
-@pytest.fixture
-def mock_toggl_detailed_time_entries(mock_toggl_api, toggl_file):
-    mock_csv_bytes = Path(toggl_file).read_bytes()
-    mock_toggl_api.detailed_time_entries.return_value.content = mock_csv_bytes
-    return mock_toggl_api
+class TestTogglTime:
 
+    @pytest.fixture(autouse=True)
+    def setup(self, mocker):
+        self.time = TogglTime()
+        self.time.toggl = mocker.Mock()
 
-def test_get_first_name_matching(mock_user_info):
-    mock_user_info.return_value = {"email": {"First Name": "User"}}
+    @pytest.fixture
+    def mock_toggl_detailed_time_entries(self, toggl_file):
+        mock_csv_bytes = Path(toggl_file).read_bytes()
+        self.time.toggl.detailed_time_entries.return_value.content = mock_csv_bytes
+        return self.time.toggl.detailed_time_entries
 
-    result = _get_first_name("email")
+    def test_get_first_name_matching(self, mock_user_info):
+        mock_user_info.return_value = {"email": {"First Name": "User"}}
 
-    assert result == "User"
+        result = self.time._get_first_name("email")
 
+        assert result == "User"
 
-def test_get_first_name_lookup_with_record(mock_user_info, mock_google_user_info):
-    email = "user@email.com"
-    mock_user_info.return_value = {email: {"Data": 1234}}
-    mock_google_user_info.return_value = {"First Name": "User"}
+    def test_get_first_name_lookup_with_record(self, mock_user_info, mock_google_user_info):
+        email = "user@email.com"
+        mock_user_info.return_value = {email: {"Data": 1234}}
+        mock_google_user_info.return_value = {"First Name": "User"}
 
-    result = _get_first_name(email)
+        result = self.time._get_first_name(email)
 
-    assert result == "User"
-    assert mock_user_info.return_value[email]["First Name"] == "User"
-    assert mock_user_info.return_value[email]["Data"] == 1234
-    mock_google_user_info.assert_called_once_with(email)
+        assert result == "User"
+        assert mock_user_info.return_value[email]["First Name"] == "User"
+        assert mock_user_info.return_value[email]["Data"] == 1234
+        mock_google_user_info.assert_called_once_with(email)
 
+    def test_get_first_name_lookup_without_record(self, mock_user_info, mock_google_user_info):
+        email = "user@email.com"
+        mock_user_info.return_value = {email: {}}
+        mock_google_user_info.return_value = {"First Name": "User"}
 
-def test_get_first_name_lookup_without_record(mock_user_info, mock_google_user_info):
-    email = "user@email.com"
-    mock_user_info.return_value = {email: {}}
-    mock_google_user_info.return_value = {"First Name": "User"}
+        result = self.time._get_first_name(email)
 
-    result = _get_first_name(email)
+        assert result == "User"
+        assert mock_user_info.return_value[email]["First Name"] == "User"
+        assert list(mock_user_info.return_value[email].keys()) == ["First Name"]
+        mock_google_user_info.assert_called_once_with(email)
 
-    assert result == "User"
-    assert mock_user_info.return_value[email]["First Name"] == "User"
-    assert list(mock_user_info.return_value[email].keys()) == ["First Name"]
-    mock_google_user_info.assert_called_once_with(email)
+    def test_get_last_name_matching(self, mock_user_info, mock_google_user_info):
+        mock_user_info.return_value = {"email": {"Last Name": "User"}}
 
+        result = self.time._get_last_name("email")
 
-def test_get_last_name_matching(mock_user_info, mock_google_user_info):
-    mock_user_info.return_value = {"email": {"Last Name": "User"}}
+        assert result == "User"
+        mock_google_user_info.assert_not_called()
 
-    result = _get_last_name("email")
+    def test_get_last_name_lookup_with_record(self, mock_user_info, mock_google_user_info):
+        email = "user@email.com"
+        mock_user_info.return_value = {email: {"Data": 1234}}
+        mock_google_user_info.return_value = {"Last Name": "User"}
 
-    assert result == "User"
-    mock_google_user_info.assert_not_called()
+        result = self.time._get_last_name(email)
 
+        assert result == "User"
+        assert mock_user_info.return_value[email]["Last Name"] == "User"
+        assert mock_user_info.return_value[email]["Data"] == 1234
+        mock_google_user_info.assert_called_once_with(email)
 
-def test_get_last_name_lookup_with_record(mock_user_info, mock_google_user_info):
-    email = "user@email.com"
-    mock_user_info.return_value = {email: {"Data": 1234}}
-    mock_google_user_info.return_value = {"Last Name": "User"}
+    def test_get_last_name_lookup_without_record(self, mock_user_info, mock_google_user_info):
+        email = "user@email.com"
+        mock_user_info.return_value = {email: {}}
+        mock_google_user_info.return_value = {"Last Name": "User"}
 
-    result = _get_last_name(email)
+        result = self.time._get_last_name(email)
 
-    assert result == "User"
-    assert mock_user_info.return_value[email]["Last Name"] == "User"
-    assert mock_user_info.return_value[email]["Data"] == 1234
-    mock_google_user_info.assert_called_once_with(email)
+        assert result == "User"
+        assert mock_user_info.return_value[email]["Last Name"] == "User"
+        assert list(mock_user_info.return_value[email].keys()) == ["Last Name"]
+        mock_google_user_info.assert_called_once_with(email)
 
+    def test_str_timedelta(self):
+        dt = "01:30:15"
 
-def test_get_last_name_lookup_without_record(mock_user_info, mock_google_user_info):
-    email = "user@email.com"
-    mock_user_info.return_value = {email: {}}
-    mock_google_user_info.return_value = {"Last Name": "User"}
+        result = self.time._str_timedelta(dt)
 
-    result = _get_last_name(email)
+        assert isinstance(result, timedelta)
+        assert result.total_seconds() == (1 * 60 * 60) + (30 * 60) + 15
 
-    assert result == "User"
-    assert mock_user_info.return_value[email]["Last Name"] == "User"
-    assert list(mock_user_info.return_value[email].keys()) == ["Last Name"]
-    mock_google_user_info.assert_called_once_with(email)
+    @pytest.mark.usefixtures("mock_google_user_info")
+    def test_prepare_input(self, toggl_file, spy_files):
+        df = self.time._prepare_input(toggl_file)
 
+        spy_files.read_csv.assert_called_once()
+        call_args = spy_files.read_csv.call_args
+        assert (toggl_file,) in call_args
+        assert call_args.kwargs["usecols"] == TogglTime.TOGGL_COLUMNS
+        assert call_args.kwargs["parse_dates"] == ["Start date"]
+        assert call_args.kwargs["cache_dates"] is True
 
-def test_str_timedelta():
-    dt = "01:30:15"
+        df_cols = df.columns.to_list()
 
-    result = _str_timedelta(dt)
+        assert "First name" in df_cols
+        assert "Last name" in df_cols
+        assert df["Start date"].dtype.name == "datetime64[us]"
+        assert df["Start time"].dtype.name == "timedelta64[us]"
+        assert df["Duration"].dtype.name == "timedelta64[us]"
+        assert df["Hours"].dtype.name == "float64"
+
+        df = self.time._prepare_input(toggl_file, column_renames={"Start date": "SD", "Start time": "ST", "Duration": "D"})
+
+        assert "Start date" not in df.columns
+        assert "Start time" not in df.columns
+        assert "Duration" not in df.columns
+        assert df["SD"].dtype.name == "datetime64[us]"
+        assert df["ST"].dtype.name == "timedelta64[us]"
+        assert df["D"].dtype.name == "timedelta64[us]"
 
-    assert isinstance(result, timedelta)
-    assert result.total_seconds() == (1 * 60 * 60) + (30 * 60) + 15
+    def test_converters(self):
+        assert self.time.converters.get("harvest") == self.time.convert_to_harvest
+        assert self.time.converters.get("justworks") == self.time.convert_to_justworks
+        assert self.time.converters.get("nope") is None
+
+    def test_convert_to_harvest_mocked(self, toggl_file, spy_files, mock_google_user_info):
+        mock_google_user_info.return_value = {}
+
+        self.time.convert_to_harvest(toggl_file, client_name=None)
+
+        spy_files.write_csv.assert_called_once()
+        call_args = spy_files.write_csv.call_args
+        assert sys.stdout in call_args[0]
+        assert call_args.kwargs["columns"] == TogglTime.HARVEST_COLUMNS
 
-
-@pytest.mark.usefixtures("mock_google_user_info")
-def test_prepare_input(toggl_file, spy_files):
-    df = _prepare_input(toggl_file)
-
-    spy_files.read_csv.assert_called_once()
-    call_args = spy_files.read_csv.call_args
-    assert (toggl_file,) in call_args
-    assert call_args.kwargs["usecols"] == TOGGL_COLUMNS
-    assert call_args.kwargs["parse_dates"] == ["Start date"]
-    assert call_args.kwargs["cache_dates"] is True
-
-    df_cols = df.columns.to_list()
-
-    assert "First name" in df_cols
-    assert "Last name" in df_cols
-    assert df["Start date"].dtype.name == "datetime64[us]"
-    assert df["Start time"].dtype.name == "timedelta64[us]"
-    assert df["Duration"].dtype.name == "timedelta64[us]"
-    assert df["Hours"].dtype.name == "float64"
-
-    df = _prepare_input(toggl_file, column_renames={"Start date": "SD", "Start time": "ST", "Duration": "D"})
-
-    assert "Start date" not in df.columns
-    assert "Start time" not in df.columns
-    assert "Duration" not in df.columns
-    assert df["SD"].dtype.name == "datetime64[us]"
-    assert df["ST"].dtype.name == "timedelta64[us]"
-    assert df["D"].dtype.name == "timedelta64[us]"
-
-
-def test_convert_to_harvest_mocked(toggl_file, spy_files, mock_google_user_info):
-    mock_google_user_info.return_value = {}
-
-    convert_to_harvest(toggl_file, client_name=None)
-
-    spy_files.write_csv.assert_called_once()
-    call_args = spy_files.write_csv.call_args
-    assert sys.stdout in call_args[0]
-    assert call_args.kwargs["columns"] == HARVEST_COLUMNS
-
-
-def test_convert_to_harvest_sample(toggl_file, harvest_file, mock_google_user_info):
-    mock_google_user_info.return_value = {}
-    output = None
-
-    with StringIO() as output_data:
-        convert_to_harvest(toggl_file, output_data, client_name="Test Client 123")
-        output = output_data.getvalue()
-
-    assert output
-    assert isinstance(output, str)
-    assert ",".join(HARVEST_COLUMNS) in output
-
-    order = ["Date", "First name", "Hours"]
-    sample_output_df = pd.read_csv(harvest_file).sort_values(order)
-    output_df = pd.read_csv(StringIO(output)).sort_values(order)
-
-    assert set(output_df.columns.to_list()) <= set(sample_output_df.columns.to_list())
-    assert output_df["Client"].eq("Test Client 123").all()
-
-
-def test_convert_to_harvest_with_duplicates(mock_google_user_info):
-    # Test that seemingly duplicate time entries are disambiguated
-
-    mock_google_user_info.return_value = {"First Name": "Test", "Last Name": "User"}
-    csv_input = """Email,Project,Task,Client,Start date,Start time,Duration,Description
-test@example.com,Compiler,Backend,ACME,2025-11-18,09:00:00,01:00:00,A task
-test@example.com,Compiler,Backend,ACME,2025-11-18,10:00:00,01:00:00,A task
-test@example.com,Compiler,Backend,ACME,2025-11-18,11:00:00,02:00:00,Another task
-"""
-    input_buffer = StringIO(csv_input)
-    output_buffer = StringIO()
-
-    convert_to_harvest(source_path=input_buffer, output_path=output_buffer, client_name="ACME")
-
-    output_buffer.seek(0)
-    df = pd.read_csv(output_buffer)
-
-    assert df.loc[0, "Notes"] == "[Backend] A task (1/2)"
-    assert df.loc[1, "Notes"] == "[Backend] A task (2/2)"
-    assert df.loc[2, "Notes"] == "[Backend] Another task"
-
-
-def test_convert_to_justworks_mocked(toggl_file, spy_files):
-    convert_to_justworks(toggl_file)
-
-    spy_files.write_csv.assert_called_once()
-    call_args = spy_files.write_csv.call_args
-    assert sys.stdout in call_args[0]
-    assert call_args.kwargs["columns"] == JUSTWORKS_COLUMNS
-
-
-def test_convert_to_justworks_sample(toggl_file, justworks_file):
-    output = None
-
-    with StringIO() as output_data:
-        convert_to_justworks(toggl_file, output_data)
-        output = output_data.getvalue()
-
-    assert output
-    assert isinstance(output, str)
-    assert ",".join(JUSTWORKS_COLUMNS) in output
-
-    order = ["Start Date", "First Name", "Regular Hours"]
-    sample_output_df = pd.read_csv(justworks_file).sort_values(order)
-    output_df = pd.read_csv(StringIO(output)).sort_values(order)
-
-    assert set(output_df.columns.to_list()) <= set(sample_output_df.columns.to_list())
-    assert output_df.shape == sample_output_df.shape
-
-
-@pytest.mark.usefixtures("mock_toggl_api_env", "mock_toggl_detailed_time_entries")
-def test_download_time_entries(toggl_file):
-    dt = datetime.now()
-    mock_csv_bytes = Path(toggl_file).read_bytes()
-
-    with NamedTemporaryFile("w") as temp:
-        download_time_entries(dt, dt, temp.name)
-        temp.flush()
-        response_csv_bytes = Path(temp.name).read_bytes()
-
-        # load each CSV into a DataFrame
-        mock_df = pd.read_csv(BytesIO(mock_csv_bytes))
-        response_df = pd.read_csv(BytesIO(response_csv_bytes))
-
-        # check that the response DataFrame has all columns from the mock DataFrame
-        assert set(response_df.columns.to_list()).issubset(mock_df.columns.to_list())
-
-        # check that all column values from response DataFrame are the same
-        # as corresponding column values from the mock DataFrame
-        for col in response_df.columns:
-            assert response_df[col].equals(mock_df[col])
-
-
-@pytest.mark.usefixtures("mock_toggl_api_env")
-def test_lock_time_entries(mock_toggl_api):
-    lock_date = datetime(2025, 10, 11)
-    lock_time_entries(lock_date)
-
-    mock_toggl_api.update_workspace_preferences.assert_called_once_with(report_locked_at="2025-10-11")
-
-
-def test_summarize(toggl_file):
-    """Test that summarize returns a valid TimeSummary object."""
-    summary = summarize(toggl_file)
-
-    assert summary.earliest_date == date(2023, 1, 2)
-    assert summary.latest_date == date(2023, 1, 30)
-    assert summary.total_rows == 250
-    assert math.isclose(summary.total_hours, 518.32, rel_tol=1e-5)
-    assert len(summary.hours_per_project) > 0
-    assert len(summary.hours_per_user_project) > 0
-
-
-def test_converters():
-    assert CONVERTERS.get("harvest") == convert_to_harvest
-    assert CONVERTERS.get("justworks") == convert_to_justworks
+    def test_convert_to_harvest_sample(self, toggl_file, harvest_file, mock_google_user_info):
+        mock_google_user_info.return_value = {}
+        output = None
+
+        with StringIO() as output_data:
+            self.time.convert_to_harvest(toggl_file, output_data, client_name="Test Client 123")
+            output = output_data.getvalue()
+
+        assert output
+        assert isinstance(output, str)
+        assert ",".join(TogglTime.HARVEST_COLUMNS) in output
+
+        order = ["Date", "First name", "Hours"]
+        sample_output_df = pd.read_csv(harvest_file).sort_values(order)
+        output_df = pd.read_csv(StringIO(output)).sort_values(order)
+
+        assert set(output_df.columns.to_list()) <= set(sample_output_df.columns.to_list())
+        assert output_df["Client"].eq("Test Client 123").all()
+
+    def test_convert_to_harvest_with_duplicates(self, mock_google_user_info):
+        # Test that seemingly duplicate time entries are disambiguated
+
+        mock_google_user_info.return_value = {"First Name": "Test", "Last Name": "User"}
+        csv_input = """Email,Project,Task,Client,Start date,Start time,Duration,Description
+    test@example.com,Compiler,Backend,ACME,2025-11-18,09:00:00,01:00:00,A task
+    test@example.com,Compiler,Backend,ACME,2025-11-18,10:00:00,01:00:00,A task
+    test@example.com,Compiler,Backend,ACME,2025-11-18,11:00:00,02:00:00,Another task
+    """
+        input_buffer = StringIO(csv_input)
+        output_buffer = StringIO()
+
+        self.time.convert_to_harvest(source_path=input_buffer, output_path=output_buffer, client_name="ACME")
+
+        output_buffer.seek(0)
+        df = pd.read_csv(output_buffer)
+
+        assert df.loc[0, "Notes"] == "[Backend] A task (1/2)"
+        assert df.loc[1, "Notes"] == "[Backend] A task (2/2)"
+        assert df.loc[2, "Notes"] == "[Backend] Another task"
+
+    def test_convert_to_justworks_mocked(self, toggl_file, spy_files):
+        self.time.convert_to_justworks(toggl_file)
+
+        spy_files.write_csv.assert_called_once()
+        call_args = spy_files.write_csv.call_args
+        assert sys.stdout in call_args[0]
+        assert call_args.kwargs["columns"] == TogglTime.JUSTWORKS_COLUMNS
+
+    def test_convert_to_justworks_sample(self, toggl_file, justworks_file):
+        output = None
+
+        with StringIO() as output_data:
+            self.time.convert_to_justworks(toggl_file, output_data)
+            output = output_data.getvalue()
+
+        assert output
+        assert isinstance(output, str)
+        assert ",".join(TogglTime.JUSTWORKS_COLUMNS) in output
+
+        order = ["Start Date", "First Name", "Regular Hours"]
+        sample_output_df = pd.read_csv(justworks_file).sort_values(order)
+        output_df = pd.read_csv(StringIO(output)).sort_values(order)
+
+        assert set(output_df.columns.to_list()) <= set(sample_output_df.columns.to_list())
+        assert output_df.shape == sample_output_df.shape
+
+    @pytest.mark.usefixtures("mock_toggl_api_env", "mock_toggl_detailed_time_entries")
+    def test_download(self, toggl_file):
+        dt = datetime.now()
+        mock_csv_bytes = Path(toggl_file).read_bytes()
+
+        with NamedTemporaryFile("w") as temp:
+            self.time.download(dt, dt, temp.name)
+            temp.flush()
+            response_csv_bytes = Path(temp.name).read_bytes()
+
+            # load each CSV into a DataFrame
+            mock_df = pd.read_csv(BytesIO(mock_csv_bytes))
+            response_df = pd.read_csv(BytesIO(response_csv_bytes))
+
+            # check that the response DataFrame has all columns from the mock DataFrame
+            assert set(response_df.columns.to_list()).issubset(mock_df.columns.to_list())
+
+            # check that all column values from response DataFrame are the same
+            # as corresponding column values from the mock DataFrame
+            for col in response_df.columns:
+                assert response_df[col].equals(mock_df[col])
+
+    @pytest.mark.usefixtures("mock_toggl_api_env")
+    def test_lock(self):
+        lock_date = datetime(2025, 10, 11)
+        self.time.lock(lock_date)
+
+        self.time.toggl.update_workspace_preferences.assert_called_once_with(report_locked_at="2025-10-11")
+
+    def test_summarize(self, toggl_file):
+        """Test that summarize returns a valid TimeSummary object."""
+        summary = self.time.summarize(toggl_file)
+
+        assert summary.earliest_date == date(2023, 1, 2)
+        assert summary.latest_date == date(2023, 1, 30)
+        assert summary.total_rows == 250
+        assert math.isclose(summary.total_hours, 518.32, rel_tol=1e-5)
+        assert len(summary.hours_per_project) > 0
+        assert len(summary.hours_per_user_project) > 0

--- a/tests/services/test_toggl.py
+++ b/tests/services/test_toggl.py
@@ -46,13 +46,13 @@ class TestTogglTime:
     @pytest.fixture(autouse=True)
     def setup(self, mocker):
         self.time = TogglTime()
-        self.time.toggl = mocker.Mock()
+        self.time.api = mocker.Mock()
 
     @pytest.fixture
     def mock_toggl_detailed_time_entries(self, toggl_file):
         mock_csv_bytes = Path(toggl_file).read_bytes()
-        self.time.toggl.detailed_time_entries.return_value.content = mock_csv_bytes
-        return self.time.toggl.detailed_time_entries
+        self.time.api.detailed_time_entries.return_value.content = mock_csv_bytes
+        return self.time.api.detailed_time_entries
 
     def test_get_first_name_matching(self, mock_user_info):
         mock_user_info.return_value = {"email": {"First Name": "User"}}
@@ -262,7 +262,7 @@ class TestTogglTime:
         lock_date = datetime(2025, 10, 11)
         self.time.lock(lock_date)
 
-        self.time.toggl.update_workspace_preferences.assert_called_once_with(report_locked_at="2025-10-11")
+        self.time.api.update_workspace_preferences.assert_called_once_with(report_locked_at="2025-10-11")
 
     def test_summarize(self, toggl_file):
         """Test that summarize returns a valid TimeSummary object."""

--- a/tests/services/test_toggl.py
+++ b/tests/services/test_toggl.py
@@ -46,13 +46,14 @@ class TestTogglTime:
     @pytest.fixture(autouse=True)
     def setup(self, mocker):
         self.time = TogglTime()
-        self.time.api = mocker.Mock()
+        self.time.reports_api = mocker.Mock()
+        self.time.workspace_api = mocker.Mock()
 
     @pytest.fixture
     def mock_toggl_detailed_time_entries(self, toggl_file):
         mock_csv_bytes = Path(toggl_file).read_bytes()
-        self.time.api.detailed_time_entries.return_value.content = mock_csv_bytes
-        return self.time.api.detailed_time_entries
+        self.time.reports_api.detailed_time_entries.return_value.content = mock_csv_bytes
+        return self.time.reports_api.detailed_time_entries
 
     def test_get_first_name_matching(self, mock_user_info):
         mock_user_info.return_value = {"email": {"First Name": "User"}}
@@ -262,7 +263,7 @@ class TestTogglTime:
         lock_date = datetime(2025, 10, 11)
         self.time.lock(lock_date)
 
-        self.time.api.update_workspace_preferences.assert_called_once_with(report_locked_at="2025-10-11")
+        self.time.workspace_api.update_preferences.assert_called_once_with(report_locked_at="2025-10-11")
 
     def test_summarize(self, toggl_file):
         """Test that summarize returns a valid TimeSummary object."""


### PR DESCRIPTION
Organizes code into more meaningful classes in:

- `compiler_admin.api.toggl`
- `compiler_admin.services.harvest`
- `compiler_admin.services.toggl`

This will allow for more natural expansion of the Toggl API and capabilities, while keeping the integration with the CLI flexible. 