### PR TITLE
Feat: command to list users

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,9 +23,10 @@
         "esbenp.prettier-vscode",
         "mechatroner.rainbow-csv",
         "mhutchie.git-graph",
-        "ms-python.python",
         "ms-python.black-formatter",
+        "ms-python.isort",
         "ms-python.flake8",
+        "ms-python.python",
         "ms-toolsai.jupyter",
         "tamasfe.even-better-toml"
       ]

--- a/.devcontainer/postAttach.sh
+++ b/.devcontainer/postAttach.sh
@@ -2,3 +2,8 @@
 set -eu
 
 pre-commit install --install-hooks
+
+# configures shell completion for bash `compiler-admin`
+# https://click.palletsprojects.com/en/stable/shell-completion/
+_COMPILER_ADMIN_COMPLETE=bash_source compiler-admin > ./compiler-admin-complete.bash
+echo "source ./compiler-admin-complete.bash" >> ~/.bashrc

--- a/.env.sample
+++ b/.env.sample
@@ -8,5 +8,6 @@ TOGGL_USER_INFO=data/toggl-user-info-sample.json
 TOGGL_API_TOKEN=token
 TOGGL_CLIENT_ID=client
 TOGGL_WORKSPACE_ID=workspace
+TOGGL_ORGANIZATION_ID=organization
 
 TZ_NAME=America/Los_Angeles

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+compiler-admin-complete.bash
 GYB-GMail-Backup-*/
 __pycache__
 .config/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,8 @@
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true,
   "[python]": {
-    "editor.defaultFormatter": "ms-python.black-formatter"
+    "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.codeActionsOnSave": { "source.organizeImports": "explicit" }
   },
   "python.languageServer": "Pylance",
   "python.testing.pytestArgs": ["-m not e2e", "tests"],

--- a/compiler_admin/__init__.py
+++ b/compiler_admin/__init__.py
@@ -6,6 +6,12 @@ class Result:
     FAILURE = 1
 
 
+class Format:
+    BASIC = 0
+    CSV = 1
+    JSON = 2
+
+
 try:
     __version__ = version("compiler_admin")
 except PackageNotFoundError:

--- a/compiler_admin/__init__.py
+++ b/compiler_admin/__init__.py
@@ -1,7 +1,10 @@
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
 
-RESULT_SUCCESS = 0
-RESULT_FAILURE = 1
+
+class Result:
+    SUCCESS = 0
+    FAILURE = 1
+
 
 try:
     __version__ = version("compiler_admin")

--- a/compiler_admin/api/toggl.py
+++ b/compiler_admin/api/toggl.py
@@ -162,6 +162,21 @@ class TogglWorkspace(TogglBase):
         """The workspaces portion of an API URL."""
         return self.WORKSPACES_ID.format(self.workspace_id)
 
+    def get_users(self, **kwargs) -> requests.Response:
+        """Request a list of users from the Toggl workspace.
+
+        See https://engineering.toggl.com/docs/track/api/workspaces/#get-get-workspace-users.
+
+        Returns:
+            response (requests.Response): The HTTP response.
+        """
+        url = self.make_api_url("users")
+
+        response = self.session.get(url, timeout=self.timeout)
+        response.raise_for_status()
+
+        return response
+
     def update_preferences(self, **kwargs) -> requests.Response:
         """Update workspace preferences.
 

--- a/compiler_admin/api/toggl.py
+++ b/compiler_admin/api/toggl.py
@@ -74,8 +74,10 @@ class TogglOrganization(TogglBase):
             response (requests.Response): The HTTP response.
         """
         url = self.make_api_url("users")
+        params = dict(kwargs)
+        params["workspaces"] = str(self.workspace_id)
 
-        response = self.session.get(url, timeout=self.timeout)
+        response = self.session.get(url, params=params, timeout=self.timeout)
         response.raise_for_status()
 
         return response
@@ -171,8 +173,9 @@ class TogglWorkspace(TogglBase):
             response (requests.Response): The HTTP response.
         """
         url = self.make_api_url("users")
+        params = dict(**kwargs)
 
-        response = self.session.get(url, timeout=self.timeout)
+        response = self.session.get(url, params=params, timeout=self.timeout)
         response.raise_for_status()
 
         return response

--- a/compiler_admin/api/toggl.py
+++ b/compiler_admin/api/toggl.py
@@ -53,6 +53,34 @@ class TogglBase:
         return "/".join((TogglBase.API_BASE_URL, self.api_url_version, self.api_url_resource, endpoint))
 
 
+class TogglOrganization(TogglBase):
+    ORGANIZATIONS_ID = "organizations/{}"
+
+    def __init__(self, api_token, workspace_id, organization_id, **kwargs):
+        super().__init__(api_token, workspace_id, **kwargs)
+        self.organization_id = organization_id
+
+    @property
+    def api_url_resource(self):
+        """The organizations portion of an API URL."""
+        return self.ORGANIZATIONS_ID.format(self.organization_id)
+
+    def get_users(self, **kwargs) -> requests.Response:
+        """Request a list of users from the Toggl organization.
+
+        See https://engineering.toggl.com/docs/track/api/organizations/#get-list-of-users-in-organization.
+
+        Returns:
+            response (requests.Response): The HTTP response.
+        """
+        url = self.make_api_url("users")
+
+        response = self.session.get(url, timeout=self.timeout)
+        response.raise_for_status()
+
+        return response
+
+
 class TogglReports(TogglBase):
     REPORTS_API_VERSION = "reports/api/v3"
     WORKSPACE_ID = "workspace/{}"

--- a/compiler_admin/commands/time/download.py
+++ b/compiler_admin/commands/time/download.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timedelta
 from typing import List
+from zoneinfo import ZoneInfo
 
 import click
-from zoneinfo import ZoneInfo
 
 from compiler_admin.services.toggl import TogglTime
 

--- a/compiler_admin/commands/user/__init__.py
+++ b/compiler_admin/commands/user/__init__.py
@@ -5,6 +5,7 @@ from compiler_admin.commands.user.convert import convert
 from compiler_admin.commands.user.create import create
 from compiler_admin.commands.user.deactivate import deactivate
 from compiler_admin.commands.user.delete import delete
+from compiler_admin.commands.user.ls import ls
 from compiler_admin.commands.user.offboard import offboard
 from compiler_admin.commands.user.reactivate import reactivate
 from compiler_admin.commands.user.reset import reset
@@ -23,6 +24,7 @@ user.add_command(convert)
 user.add_command(create)
 user.add_command(deactivate)
 user.add_command(delete)
+user.add_command(ls)
 user.add_command(offboard)
 user.add_command(reactivate)
 user.add_command(reset)

--- a/compiler_admin/commands/user/backupcodes.py
+++ b/compiler_admin/commands/user/backupcodes.py
@@ -1,6 +1,6 @@
 import click
 
-from compiler_admin import RESULT_FAILURE
+from compiler_admin import Result
 from compiler_admin.services.google import get_backup_codes, user_account_name, user_exists
 
 
@@ -12,7 +12,7 @@ def backupcodes(username: str, **kwargs):
 
     if not user_exists(account):
         click.echo(f"User does not exist: {account}")
-        raise SystemExit(RESULT_FAILURE)
+        raise SystemExit(Result.FAILURE)
 
     backup_codes = get_backup_codes(account)
     click.echo(backup_codes)

--- a/compiler_admin/commands/user/convert.py
+++ b/compiler_admin/commands/user/convert.py
@@ -1,6 +1,6 @@
 import click
 
-from compiler_admin import RESULT_FAILURE
+from compiler_admin import Result
 from compiler_admin.services.google import (
     GROUP_PARTNERS,
     GROUP_STAFF,
@@ -30,7 +30,7 @@ def convert(ctx: click.Context, username: str, account_type: str, **kwargs):
 
     if not user_exists(account):
         click.echo(f"User does not exist: {account}")
-        raise SystemExit(RESULT_FAILURE)
+        raise SystemExit(Result.FAILURE)
 
     click.echo(f"User exists, converting to: {account_type} for {account}")
 
@@ -46,13 +46,13 @@ def convert(ctx: click.Context, username: str, account_type: str, **kwargs):
             remove_user_from_group(account, GROUP_PARTNERS)
         elif user_is_staff(account):
             click.echo(f"User is already staff: {account}")
-            raise SystemExit(RESULT_FAILURE)
+            raise SystemExit(Result.FAILURE)
         add_user_to_group(account, GROUP_STAFF)
 
     elif account_type == "partner":
         if user_is_partner(account):
             click.echo(f"User is already partner: {account}")
-            raise SystemExit(RESULT_FAILURE)
+            raise SystemExit(Result.FAILURE)
         if not user_is_staff(account):
             add_user_to_group(account, GROUP_STAFF)
         add_user_to_group(account, GROUP_PARTNERS)

--- a/compiler_admin/commands/user/create.py
+++ b/compiler_admin/commands/user/create.py
@@ -1,6 +1,6 @@
 import click
 
-from compiler_admin import RESULT_FAILURE
+from compiler_admin import Result
 from compiler_admin.services.google import (
     GROUP_TEAM,
     USER_HELLO,
@@ -28,7 +28,7 @@ def create(username: str, notify: str = "", gam_args: list = []):
 
     if user_exists(account):
         click.echo(f"User already exists: {account}")
-        raise SystemExit(RESULT_FAILURE)
+        raise SystemExit(Result.FAILURE)
 
     click.echo(f"User does not exist, continuing: {account}")
 

--- a/compiler_admin/commands/user/deactivate.py
+++ b/compiler_admin/commands/user/deactivate.py
@@ -1,6 +1,6 @@
 import click
 
-from compiler_admin import RESULT_FAILURE, RESULT_SUCCESS
+from compiler_admin import Result
 from compiler_admin.commands.user.reset import reset
 from compiler_admin.services.google import (
     OU_ALUMNI,
@@ -37,17 +37,17 @@ def deactivate(
 
     if not user_exists(account):
         click.echo(f"User does not exist: {account}")
-        raise SystemExit(RESULT_FAILURE)
+        raise SystemExit(Result.FAILURE)
 
     if user_is_deactivated(account):
         click.echo("User is already deactivated")
-        raise SystemExit(RESULT_FAILURE)
+        raise SystemExit(Result.FAILURE)
 
     if not force:
         cont = input(f"Deactivate account {account}? (Y/n): ")
         if not cont.lower().startswith("y"):
             click.echo("Aborting deactivation")
-            raise SystemExit(RESULT_SUCCESS)
+            raise SystemExit(Result.SUCCESS)
 
     click.echo(f"User exists, deactivating: {account}")
 

--- a/compiler_admin/commands/user/delete.py
+++ b/compiler_admin/commands/user/delete.py
@@ -1,6 +1,6 @@
 import click
 
-from compiler_admin import RESULT_FAILURE
+from compiler_admin import Result
 from compiler_admin.services.google import CallGAMCommand, user_account_name, user_exists
 
 
@@ -13,7 +13,7 @@ def delete(username: str, force: bool = False, **kwargs):
 
     if not user_exists(account):
         click.echo(f"User does not exist: {account}")
-        raise SystemExit(RESULT_FAILURE)
+        raise SystemExit(Result.FAILURE)
 
     if not force:
         cont = input(f"Delete account {account}? (Y/n): ")

--- a/compiler_admin/commands/user/ls.py
+++ b/compiler_admin/commands/user/ls.py
@@ -13,12 +13,7 @@ def ls_google(inactive: bool = False, **kwargs):
 def ls_toggl(inactive: bool = False, **kwargs):
     """Use the Toggl API to get a list of users."""
     toggl = TogglUsers()
-    if inactive:
-        active_status = "inactive,invited"
-    else:
-        active_status = "active"
-
-    users = toggl.get_organization_users(active_status=active_status)
+    users = toggl.get_organization_users(inactive=inactive, **kwargs)
 
     # Mirroing the default GAM output for print users
     click.echo(f"Got {len(users)} Users")

--- a/compiler_admin/commands/user/ls.py
+++ b/compiler_admin/commands/user/ls.py
@@ -1,14 +1,28 @@
 import click
 
-from compiler_admin import RESULT_SUCCESS
 from compiler_admin.services.google import CallGAMCommand
+
+USER_SYSTEMS = ["google"]
 
 
 @click.command()
-def ls(**kwargs):
+@click.option(
+    "--system",
+    help="The system from which to list accounts.",
+    type=click.Choice(USER_SYSTEMS, case_sensitive=False),
+    default="google",
+)
+def ls(system: str, **kwargs):
     """Lists users in the Compiler workspace."""
-    click.echo("Listing users in Compiler workspace")
+    match system:
+        case "google":
+            ls_google(**kwargs)
+        case _:
+            click.echo(f"Unknown user system: {system}")
+
+
+def ls_google(**kwargs):
+    click.echo("Listing users in Compiler Google workspace")
 
     command = ("print", "users")
     CallGAMCommand(command)
-    raise SystemExit(RESULT_SUCCESS)

--- a/compiler_admin/commands/user/ls.py
+++ b/compiler_admin/commands/user/ls.py
@@ -1,38 +1,82 @@
 import click
+import pandas as pd
 
+from compiler_admin import Format
+from compiler_admin.services import files
 from compiler_admin.services.google import get_users
 from compiler_admin.services.toggl import TogglUsers
 
 
-def ls_google(inactive: bool = False, **kwargs):
+def ls_google(inactive: bool = False, format: int = Format.BASIC, **kwargs):
     """Use GAM to print the users in the Google Workspace."""
-    output = get_users(inactive, **kwargs)
+    output = get_users(inactive=inactive, format=format, **kwargs)
     click.echo(output)
 
 
-def ls_toggl(inactive: bool = False, **kwargs):
+def ls_toggl(inactive: bool = False, format: int = Format.BASIC, **kwargs):
     """Use the Toggl API to get a list of users."""
     toggl = TogglUsers()
     users = toggl.get_organization_users(inactive=inactive, **kwargs)
+    users_df = pd.DataFrame(users)
 
-    # Mirroing the default GAM output for print users
-    click.echo(f"Got {len(users)} Users")
-    click.echo("email")
-    for user in users:
-        click.echo(user["email"])
+    # Mirroing the GAM output style
+    stdout = click.get_text_stream("stdout")
+
+    match format:
+        case Format.BASIC:
+            click.echo(f"Got {len(users)} Users")
+            files.write_csv(stdout, users_df, columns=["email"])
+        case Format.CSV:
+            click.echo(f"Got {len(users)} Users")
+            files.write_csv(
+                stdout,
+                users_df,
+                columns=[
+                    "email",
+                    "name",
+                    "id",
+                    "user_id",
+                    "role_id",
+                    "organization_id",
+                    "inactive",
+                    "joined",
+                    "can_edit_email",
+                    "2fa_enabled",
+                    "avatar_url",
+                ],
+            )
+        case Format.JSON:
+            files.write_json(stdout, users)
 
 
 USER_SYSTEMS = {"google": ls_google, "toggl": ls_toggl}
+FORMATS = {
+    "b": Format.BASIC,
+    "basic": Format.BASIC,
+    "c": Format.CSV,
+    "csv": Format.CSV,
+    "j": Format.JSON,
+    "json": Format.JSON,
+}
 
 
 @click.command()
 @click.option("--inactive", help="List inactive users in the system.", is_flag=True)
+@click.option(
+    "--format",
+    "format_key",
+    help="The format of the output.",
+    type=click.Choice(FORMATS.keys(), case_sensitive=False),
+    default="basic",
+)
 @click.argument(
     "system",
     type=click.Choice(USER_SYSTEMS.keys(), case_sensitive=False),
     default="google",
 )
-def ls(system: str, inactive: bool, **kwargs):
+def ls(system: str, inactive: bool, format_key: str, **kwargs):
     """List users in the Compiler workspace."""
     ls_system = USER_SYSTEMS.get(system)
-    ls_system(inactive=inactive, **kwargs)
+    format = FORMATS.get(format_key)
+
+    ls_system(inactive=inactive, format=format, **kwargs)

--- a/compiler_admin/commands/user/ls.py
+++ b/compiler_admin/commands/user/ls.py
@@ -1,28 +1,34 @@
 import click
 
+from compiler_admin.services import files
 from compiler_admin.services.google import CallGAMCommand
-
-USER_SYSTEMS = ["google"]
-
-
-@click.command()
-@click.option(
-    "--system",
-    help="The system from which to list accounts.",
-    type=click.Choice(USER_SYSTEMS, case_sensitive=False),
-    default="google",
-)
-def ls(system: str, **kwargs):
-    """Lists users in the Compiler workspace."""
-    match system:
-        case "google":
-            ls_google(**kwargs)
-        case _:
-            click.echo(f"Unknown user system: {system}")
+from compiler_admin.services.toggl import TogglUsers
 
 
 def ls_google(**kwargs):
-    click.echo("Listing users in Compiler Google workspace")
-
+    """Use GAM to print the users in the Google Workspace."""
     command = ("print", "users")
     CallGAMCommand(command)
+
+
+def ls_toggl(**kwargs):
+    """Use the Toggl API to get a list of Organization users."""
+    toggl = TogglUsers()
+
+    users = toggl.get_organization_users()
+    files.write_json(click.get_text_stream("stdout"), users)
+
+
+USER_SYSTEMS = {"google": ls_google, "toggl": ls_toggl}
+
+
+@click.command()
+@click.argument(
+    "system",
+    type=click.Choice(USER_SYSTEMS.keys(), case_sensitive=False),
+    default="google",
+)
+def ls(system: str, **kwargs):
+    """List users in the Compiler workspace SYSTEM (Google by default)."""
+    ls_system = USER_SYSTEMS.get(system)
+    ls_system(**kwargs)

--- a/compiler_admin/commands/user/ls.py
+++ b/compiler_admin/commands/user/ls.py
@@ -1,34 +1,45 @@
 import click
 
-from compiler_admin.services import files
 from compiler_admin.services.google import CallGAMCommand
 from compiler_admin.services.toggl import TogglUsers
 
 
-def ls_google(**kwargs):
+def ls_google(inactive: bool = False, **kwargs):
     """Use GAM to print the users in the Google Workspace."""
-    command = ("print", "users")
+    flag = str(inactive).lower()
+    command = ("print", "users") + ("issuspended", flag, "isarchived", flag)
+
     CallGAMCommand(command)
 
 
-def ls_toggl(**kwargs):
-    """Use the Toggl API to get a list of Organization users."""
+def ls_toggl(inactive: bool = False, **kwargs):
+    """Use the Toggl API to get a list of users."""
     toggl = TogglUsers()
+    if inactive:
+        active_status = "inactive,invited"
+    else:
+        active_status = "active"
 
-    users = toggl.get_organization_users()
-    files.write_json(click.get_text_stream("stdout"), users)
+    users = toggl.get_organization_users(active_status=active_status)
+
+    # Mirroing the default GAM output for print users
+    click.echo(f"Got {len(users)} Users")
+    click.echo("email")
+    for user in users:
+        click.echo(user["email"])
 
 
 USER_SYSTEMS = {"google": ls_google, "toggl": ls_toggl}
 
 
 @click.command()
+@click.option("--inactive", help="List inactive users in the system.", is_flag=True)
 @click.argument(
     "system",
     type=click.Choice(USER_SYSTEMS.keys(), case_sensitive=False),
     default="google",
 )
-def ls(system: str, **kwargs):
-    """List users in the Compiler workspace SYSTEM (Google by default)."""
+def ls(system: str, inactive: bool, **kwargs):
+    """List users in the Compiler workspace."""
     ls_system = USER_SYSTEMS.get(system)
-    ls_system(**kwargs)
+    ls_system(inactive=inactive, **kwargs)

--- a/compiler_admin/commands/user/ls.py
+++ b/compiler_admin/commands/user/ls.py
@@ -1,0 +1,14 @@
+import click
+
+from compiler_admin import RESULT_SUCCESS
+from compiler_admin.services.google import CallGAMCommand
+
+
+@click.command()
+def ls(**kwargs):
+    """Lists users in the Compiler workspace."""
+    click.echo("Listing users in Compiler workspace")
+
+    command = ("print", "users")
+    CallGAMCommand(command)
+    raise SystemExit(RESULT_SUCCESS)

--- a/compiler_admin/commands/user/ls.py
+++ b/compiler_admin/commands/user/ls.py
@@ -1,15 +1,13 @@
 import click
 
-from compiler_admin.services.google import CallGAMCommand
+from compiler_admin.services.google import get_users
 from compiler_admin.services.toggl import TogglUsers
 
 
 def ls_google(inactive: bool = False, **kwargs):
     """Use GAM to print the users in the Google Workspace."""
-    flag = str(inactive).lower()
-    command = ("print", "users") + ("issuspended", flag, "isarchived", flag)
-
-    CallGAMCommand(command)
+    output = get_users(inactive, **kwargs)
+    click.echo(output)
 
 
 def ls_toggl(inactive: bool = False, **kwargs):

--- a/compiler_admin/commands/user/offboard.py
+++ b/compiler_admin/commands/user/offboard.py
@@ -2,7 +2,7 @@ from tempfile import NamedTemporaryFile
 
 import click
 
-from compiler_admin import RESULT_FAILURE, RESULT_SUCCESS
+from compiler_admin import Result
 from compiler_admin.commands.user.deactivate import deactivate
 from compiler_admin.commands.user.delete import delete
 from compiler_admin.services.google import USER_ARCHIVE, CallGAMCommand, CallGYBCommand, user_account_name, user_exists
@@ -24,18 +24,18 @@ def offboard(ctx: click.Context, username: str, alias: str = "", _delete: bool =
 
     if not user_exists(account):
         click.echo(f"User does not exist: {account}")
-        raise SystemExit(RESULT_FAILURE)
+        raise SystemExit(Result.FAILURE)
 
     alias_account = user_account_name(alias)
     if alias_account and not user_exists(alias_account):
         click.echo(f"Alias target user does not exist: {alias_account}")
-        raise SystemExit(RESULT_FAILURE)
+        raise SystemExit(Result.FAILURE)
 
     if not force:
         cont = input(f"Offboard account {account} {' (assigning alias to ' + alias_account + ')' if alias else ''}? (Y/n): ")
         if not cont.lower().startswith("y"):
             click.echo("Aborting offboard.")
-            raise SystemExit(RESULT_SUCCESS)
+            raise SystemExit(Result.SUCCESS)
 
     click.echo(f"User exists, offboarding: {account}")
 

--- a/compiler_admin/commands/user/reactivate.py
+++ b/compiler_admin/commands/user/reactivate.py
@@ -1,6 +1,6 @@
 import click
 
-from compiler_admin import RESULT_FAILURE, RESULT_SUCCESS
+from compiler_admin import Result
 from compiler_admin.commands.user.backupcodes import backupcodes
 from compiler_admin.commands.user.reset import reset
 from compiler_admin.services.google import (
@@ -49,17 +49,17 @@ def reactivate(
 
     if not user_exists(account):
         click.echo(f"User does not exist: {account}")
-        raise SystemExit(RESULT_FAILURE)
+        raise SystemExit(Result.FAILURE)
 
     if not user_is_deactivated(account):
         click.echo("User is not deactivated, cannot reactivate")
-        raise SystemExit(RESULT_FAILURE)
+        raise SystemExit(Result.FAILURE)
 
     if not force:
         cont = input(f"Reactivate account {account}? (Y/n): ")
         if not cont.lower().startswith("y"):
             click.echo("Aborting reactivation")
-            raise SystemExit(RESULT_SUCCESS)
+            raise SystemExit(Result.SUCCESS)
 
     click.echo(f"User exists, reactivating: {account}")
 

--- a/compiler_admin/commands/user/reset.py
+++ b/compiler_admin/commands/user/reset.py
@@ -1,6 +1,6 @@
 import click
 
-from compiler_admin import RESULT_FAILURE, RESULT_SUCCESS
+from compiler_admin import Result
 from compiler_admin.commands.user.signout import signout
 from compiler_admin.services.google import USER_HELLO, CallGAMCommand, user_account_name, user_exists
 
@@ -16,13 +16,13 @@ def reset(ctx: click.Context, username: str, force: bool = False, notify: str = 
 
     if not user_exists(account):
         click.echo(f"User does not exist: {account}")
-        raise SystemExit(RESULT_FAILURE)
+        raise SystemExit(Result.FAILURE)
 
     if not force:
         cont = input(f"Reset password for {account}? (Y/n): ")
         if not cont.lower().startswith("y"):
             click.echo("Aborting password reset.")
-            raise SystemExit(RESULT_SUCCESS)
+            raise SystemExit(Result.SUCCESS)
 
     click.echo(f"User exists, resetting password: {account}")
 

--- a/compiler_admin/commands/user/restore.py
+++ b/compiler_admin/commands/user/restore.py
@@ -2,7 +2,7 @@ import pathlib
 
 import click
 
-from compiler_admin import RESULT_FAILURE
+from compiler_admin import Result
 from compiler_admin.services.google import USER_ARCHIVE, CallGYBCommand, user_account_name
 
 
@@ -15,7 +15,7 @@ def restore(username: str):
 
     if not pathlib.Path(backup_dir).exists():
         click.echo(f"Couldn't find a local backup: {backup_dir}")
-        raise SystemExit(RESULT_FAILURE)
+        raise SystemExit(Result.FAILURE)
 
     click.echo(f"Found backup, starting restore process with dest: {USER_ARCHIVE} for account: {account}")
 

--- a/compiler_admin/commands/user/signout.py
+++ b/compiler_admin/commands/user/signout.py
@@ -1,6 +1,6 @@
 import click
 
-from compiler_admin import RESULT_FAILURE, RESULT_SUCCESS
+from compiler_admin import Result
 from compiler_admin.services.google import CallGAMCommand, user_account_name, user_exists
 
 
@@ -13,13 +13,13 @@ def signout(username: str, force: bool = False, **kwargs):
 
     if not user_exists(account):
         click.echo(f"User does not exist: {account}")
-        raise SystemExit(RESULT_FAILURE)
+        raise SystemExit(Result.FAILURE)
 
     if not force:
         cont = input(f"Signout account {account} from all active sessions? (Y/n): ")
         if not cont.lower().startswith("y"):
             click.echo("Aborting signout.")
-            raise SystemExit(RESULT_SUCCESS)
+            raise SystemExit(Result.SUCCESS)
 
     click.echo(f"User exists, signing out from all active sessions: {account}")
 

--- a/compiler_admin/services/files.py
+++ b/compiler_admin/services/files.py
@@ -1,6 +1,8 @@
 import json
 import os
+from io import TextIOBase
 from pathlib import Path
+from typing import TextIO
 
 import pandas as pd
 
@@ -10,10 +12,16 @@ def read_csv(file_path, **kwargs) -> pd.DataFrame:
     return pd.read_csv(file_path, **kwargs)
 
 
-def read_json(file_path: str):
+def read_json(file_path):
     """Read a file path of JSON data into a python object."""
-    with open(file_path, "r") as f:
-        return json.load(f)
+
+    if isinstance(file_path, (str, Path)):
+        with open(file_path, "r") as f:
+            return json.load(f)
+    elif isinstance(file_path, (TextIOBase, TextIO)):
+        return json.load(file_path)
+    else:
+        raise NotImplementedError(f"Input type for file_path not allowed: {type(file_path)}")
 
 
 def write_csv(file_path, data: pd.DataFrame, columns: list[str] = None):
@@ -21,10 +29,15 @@ def write_csv(file_path, data: pd.DataFrame, columns: list[str] = None):
     data.to_csv(file_path, columns=columns, index=False)
 
 
-def write_json(file_path: str, data):
+def write_json(file_path, data):
     """Write a python object as JSON to the given path."""
-    with open(file_path, "w") as f:
-        json.dump(data, f, indent=2)
+    if isinstance(file_path, (str, Path)):
+        with open(file_path, "w") as f:
+            json.dump(data, f, indent=2)
+    elif isinstance(file_path, (TextIOBase, TextIO)):
+        json.dump(data, file_path, indent=2)
+    else:
+        raise NotImplementedError(f"Input type for file_path not allowed: {type(file_path)}")
 
 
 class JsonFileCache:

--- a/compiler_admin/services/google.py
+++ b/compiler_admin/services/google.py
@@ -6,7 +6,7 @@ from typing import IO, Any, Sequence
 # import and alias CallGAMCommand so we can simplify usage in this app
 from gam import CallGAMCommand as __CallGAMCommand, initializeLogging
 
-from compiler_admin import RESULT_SUCCESS
+from compiler_admin import Result
 
 initializeLogging()
 
@@ -153,7 +153,7 @@ def user_info(username: str) -> dict:
 
     with NamedTemporaryFile("w+") as stdout:
         res = CallGAMCommand(("info", "user", username, "quick"), stdout=stdout.name)
-        if res != RESULT_SUCCESS:
+        if res != Result.SUCCESS:
             # user doesn't exist
             return {}
         # user exists, read data

--- a/compiler_admin/services/google.py
+++ b/compiler_admin/services/google.py
@@ -1,12 +1,12 @@
 import subprocess
 import sys
 from tempfile import NamedTemporaryFile
-from typing import Any, Sequence, IO
-
-from compiler_admin import RESULT_SUCCESS
+from typing import IO, Any, Sequence
 
 # import and alias CallGAMCommand so we can simplify usage in this app
 from gam import CallGAMCommand as __CallGAMCommand, initializeLogging
+
+from compiler_admin import RESULT_SUCCESS
 
 initializeLogging()
 
@@ -93,6 +93,21 @@ def get_backup_codes(username: str) -> str:
         with NamedTemporaryFile("w+") as stdout:
             CallGAMCommand(command, stdout=stdout.name, stderr="stdout")
             output = "".join(stdout.readlines())
+
+    return output
+
+
+def get_users(inactive: bool = False, **kwargs) -> str:
+    flag = str(inactive).lower()
+    output = ""
+    command = ("print", "users", "issuspended", flag, "isarchived", flag)
+    if len(kwargs) > 0:
+        for k, v in kwargs.items():
+            command += (k, v)
+
+    with NamedTemporaryFile("w+") as stdout:
+        CallGAMCommand(command, stdout=stdout.name, stderr="stdout")
+        output = "".join(stdout.readlines())
 
     return output
 

--- a/compiler_admin/services/google.py
+++ b/compiler_admin/services/google.py
@@ -6,7 +6,7 @@ from typing import IO, Any, Sequence
 # import and alias CallGAMCommand so we can simplify usage in this app
 from gam import CallGAMCommand as __CallGAMCommand, initializeLogging
 
-from compiler_admin import Result
+from compiler_admin import Format, Result
 
 initializeLogging()
 
@@ -97,13 +97,19 @@ def get_backup_codes(username: str) -> str:
     return output
 
 
-def get_users(inactive: bool = False, **kwargs) -> str:
+def get_users(inactive: bool = False, format=Format.BASIC, **kwargs) -> str:
     flag = str(inactive).lower()
     output = ""
     command = ("print", "users", "issuspended", flag, "isarchived", flag)
     if len(kwargs) > 0:
         for k, v in kwargs.items():
             command += (k, v)
+
+    match format:
+        case Format.CSV:
+            command += ("full",)
+        case Format.JSON:
+            command = ("info", "users", "all", "users_arch_or_susp" if inactive else "users_na_ns", "formatjson")
 
     with NamedTemporaryFile("w+") as stdout:
         CallGAMCommand(command, stdout=stdout.name, stderr="stdout")

--- a/compiler_admin/services/time.py
+++ b/compiler_admin/services/time.py
@@ -1,7 +1,7 @@
+import math
 from dataclasses import dataclass, field
 from datetime import date
 from typing import MutableMapping
-import math
 
 
 @dataclass

--- a/compiler_admin/services/toggl.py
+++ b/compiler_admin/services/toggl.py
@@ -8,7 +8,7 @@ from typing import TextIO
 import pandas as pd
 
 import compiler_admin.services.files as files
-from compiler_admin.api.toggl import TogglReports, TogglWorkspace
+from compiler_admin.api.toggl import TogglOrganization, TogglReports, TogglWorkspace
 from compiler_admin.services.google import user_info as google_user_info
 from compiler_admin.services.time import TimeSummary
 
@@ -17,8 +17,10 @@ class TogglService:
     def __init__(self):
         token = os.environ.get("TOGGL_API_TOKEN")
         workspace = os.environ.get("TOGGL_WORKSPACE_ID")
-        self.reports_api = TogglReports(token, workspace)
-        self.workspace_api = TogglWorkspace(token, workspace)
+        organization = os.environ.get("TOGGL_ORGANIZATION_ID")
+        self.api_organization = TogglOrganization(token, workspace, organization)
+        self.api_reports = TogglReports(token, workspace)
+        self.api_workspace = TogglWorkspace(token, workspace)
 
 
 class TogglTime(TogglService):
@@ -221,7 +223,7 @@ class TogglTime(TogglService):
         Returns:
             None. Either prints the resulting CSV data or writes to output_path.
         """
-        response = self.reports_api.detailed_time_entries(start_date, end_date, **kwargs)
+        response = self.api_reports.detailed_time_entries(start_date, end_date, **kwargs)
         # the raw response has these initial 3 bytes:
         #
         #   b"\xef\xbb\xbfUser,Email,Client..."
@@ -244,7 +246,7 @@ class TogglTime(TogglService):
             lock_date (datetime): The date to lock time entries.
         """
         lock_date_str = lock_date.strftime("%Y-%m-%d")
-        self.workspace_api.update_preferences(report_locked_at=lock_date_str)
+        self.api_workspace.update_preferences(report_locked_at=lock_date_str)
 
     def normalize_summary(self, toggl_summary: TimeSummary) -> TimeSummary:
         """Normalize a Toggl TimeSummary to match the Harvest format."""

--- a/compiler_admin/services/toggl.py
+++ b/compiler_admin/services/toggl.py
@@ -310,14 +310,24 @@ class TogglTime(TogglService):
 
 
 class TogglUsers(TogglService):
-    def get_organization_users(self, **kwargs) -> dict:
+    def get_organization_users(self, inactive=False, **kwargs) -> dict:
         """Get a list of users from the Toggl organization.
+
+        Args:
+            inactive (bool): True to get inactive users. False (the default) to get only active users.
 
         Returns:
             dict: The resulting JSON data of users.
         """
+        if inactive:
+            active_status = "inactive,invited"
+        else:
+            active_status = "active"
+
+        kwargs["active_status"] = active_status
         response = self.api_organization.get_users(**kwargs)
         json = response.json()
+
         return json
 
     def get_workspace_users(self, **kwargs) -> dict:

--- a/compiler_admin/services/toggl.py
+++ b/compiler_admin/services/toggl.py
@@ -310,22 +310,22 @@ class TogglTime(TogglService):
 
 
 class TogglUsers(TogglService):
-    def get_organization_users(self) -> dict:
+    def get_organization_users(self, **kwargs) -> dict:
         """Get a list of users from the Toggl organization.
 
         Returns:
             dict: The resulting JSON data of users.
         """
-        response = self.api_organization.get_users()
+        response = self.api_organization.get_users(**kwargs)
         json = response.json()
         return json
 
-    def get_workspace_users(self) -> dict:
+    def get_workspace_users(self, **kwargs) -> dict:
         """Get a list of users from the Toggl workspace.
 
         Returns:
             dict: The resulting JSON data of users.
         """
-        response = self.api_workspace.get_users()
+        response = self.api_workspace.get_users(**kwargs)
         json = response.json()
         return json

--- a/compiler_admin/services/toggl.py
+++ b/compiler_admin/services/toggl.py
@@ -307,3 +307,31 @@ class TogglTime(TogglService):
             summary.hours_per_user_project[email][project] = hours
 
         return summary
+
+
+class TogglUsers(TogglService):
+    def get_organization_users(self, output_path: str | TextIO = sys.stdout):
+        """Get a list of users from the Toggl organization.
+
+        Args:
+            path (str | TextIO): The path to a JSON file where Toggl users will be written; or a writeable buffer for the same.
+
+        Returns:
+            None. Either prints the resulting JSON data or writes to output_path.
+        """
+        response = self.api_organization.get_users()
+        json = response.json()
+        files.write_json(output_path, json)
+
+    def get_workspace_users(self, output_path: str | TextIO = sys.stdout):
+        """Get a list of users from the Toggl workspace.
+
+        Args:
+            path (str | TextIO): The path to a JSON file where Toggl users will be written; or a writeable buffer for the same.
+
+        Returns:
+            None. Either prints the resulting JSON data or writes to output_path.
+        """
+        response = self.api_workspace.get_users()
+        json = response.json()
+        files.write_json(output_path, json)

--- a/compiler_admin/services/toggl.py
+++ b/compiler_admin/services/toggl.py
@@ -310,28 +310,22 @@ class TogglTime(TogglService):
 
 
 class TogglUsers(TogglService):
-    def get_organization_users(self, output_path: str | TextIO = sys.stdout):
+    def get_organization_users(self) -> dict:
         """Get a list of users from the Toggl organization.
 
-        Args:
-            path (str | TextIO): The path to a JSON file where Toggl users will be written; or a writeable buffer for the same.
-
         Returns:
-            None. Either prints the resulting JSON data or writes to output_path.
+            dict: The resulting JSON data of users.
         """
         response = self.api_organization.get_users()
         json = response.json()
-        files.write_json(output_path, json)
+        return json
 
-    def get_workspace_users(self, output_path: str | TextIO = sys.stdout):
+    def get_workspace_users(self) -> dict:
         """Get a list of users from the Toggl workspace.
 
-        Args:
-            path (str | TextIO): The path to a JSON file where Toggl users will be written; or a writeable buffer for the same.
-
         Returns:
-            None. Either prints the resulting JSON data or writes to output_path.
+            dict: The resulting JSON data of users.
         """
         response = self.api_workspace.get_users()
         json = response.json()
-        files.write_json(output_path, json)
+        return json

--- a/docs/guides/user/ls.md
+++ b/docs/guides/user/ls.md
@@ -1,0 +1,51 @@
+# How to Get Information About Users
+
+!!! seealso "Full Command Reference"
+
+    For a complete reference of all options, see the [`compiler-admin user ls` reference section](../../reference/cli/user.md#compiler-admin-user-ls).
+
+This guide explains how to use the `compiler-admin user ls` command to list users in the Compiler workspace.
+
+## Actions Performed
+
+The `ls` command prints information about users, such as email address, name, and user ID.
+
+## Basic Usage
+
+To list users in the Compiler workspace, call the command without any arguments:
+
+```bash
+compiler-admin user ls
+```
+
+The output will be a list of email addresses of active users in the Compiler Google workspace.
+
+## Listing Another System
+
+To list users in a specific system, use the `system` argument.
+
+```bash
+compiler-admin user ls toggl
+```
+
+## Showing Inactive Users
+
+You can view inactive users in the system with the `--inactive` flag.
+
+```bash
+compiler-admin user ls --inactive
+```
+
+## Changing the Output Format
+
+To get more user details, use the `--format` flag:
+
+```bash
+compiler-admin user ls --format csv
+```
+
+Or for even more detailed JSON output:
+
+```bash
+compiler-admin user ls --format json
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
     "build",
     "flake8",
     "ipykernel",
+    "isort",
     "pre-commit",
     "setuptools_scm>=8"
 ]
@@ -46,13 +47,19 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 127
-target-version = ['py311']
+target-version = ['py312']
 include = '\.pyi?$'
 
 [tool.coverage.run]
 branch = true
 relative_files = true
 source = ["compiler_admin"]
+
+[tool.isort]
+profile = "black"
+combine_as_imports = true
+line_length = 127
+skip_gitignore = true
 
 [tool.pyright]
 include = ["compiler_admin", "tests"]

--- a/tests/api/test_toggl.py
+++ b/tests/api/test_toggl.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from compiler_admin import __version__
-from compiler_admin.api.toggl import __name__ as MODULE, TogglBase, TogglOrganization, TogglReports, TogglWorkspace
+from compiler_admin.api.toggl import TogglBase, TogglOrganization, TogglReports, TogglWorkspace, __name__ as MODULE
 
 
 @pytest.fixture(autouse=True)
@@ -68,11 +68,13 @@ class TestTogglOrganization:
 
     def test_get_users(self, mock_requests):
         url = self.toggl.make_api_url("users")
+        kwargs = dict(kwarg1=1, kwarg2="two")
+        call_kwargs = dict(workspaces="1234", **kwargs)
 
-        response = self.toggl.get_users()
+        response = self.toggl.get_users(**kwargs)
 
         response.raise_for_status.assert_called_once()
-        mock_requests.get.assert_called_once_with(url, timeout=self.toggl.timeout)
+        mock_requests.get.assert_called_once_with(url, params=call_kwargs, timeout=self.toggl.timeout)
 
 
 class TestTogglReports:
@@ -141,11 +143,12 @@ class TestTogglWorkspace:
 
     def test_get_users(self, mock_requests):
         url = self.toggl.make_api_url("users")
+        kwargs = dict(kwarg1=1, kwarg2="two")
 
-        response = self.toggl.get_users()
+        response = self.toggl.get_users(**kwargs)
 
         response.raise_for_status.assert_called_once()
-        mock_requests.get.assert_called_once_with(url, timeout=self.toggl.timeout)
+        mock_requests.get.assert_called_once_with(url, params=kwargs, timeout=self.toggl.timeout)
 
     def test_update_preferences(self, mocker, mock_requests):
         url = "http://fake.url"

--- a/tests/api/test_toggl.py
+++ b/tests/api/test_toggl.py
@@ -139,6 +139,14 @@ class TestTogglWorkspace:
     def test_api_url_resource(self):
         assert self.toggl.api_url_resource == "workspaces/1234"
 
+    def test_get_users(self, mock_requests):
+        url = self.toggl.make_api_url("users")
+
+        response = self.toggl.get_users()
+
+        response.raise_for_status.assert_called_once()
+        mock_requests.get.assert_called_once_with(url, timeout=self.toggl.timeout)
+
     def test_update_preferences(self, mocker, mock_requests):
         url = "http://fake.url"
         mocker.patch.object(self.toggl, "make_api_url", return_value=url)

--- a/tests/api/test_toggl.py
+++ b/tests/api/test_toggl.py
@@ -4,10 +4,10 @@ from pathlib import Path
 import pytest
 
 from compiler_admin import __version__
-from compiler_admin.api.toggl import __name__ as MODULE, TogglBase, TogglReports, TogglWorkspace
+from compiler_admin.api.toggl import __name__ as MODULE, TogglBase, TogglOrganization, TogglReports, TogglWorkspace
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def mock_requests(mocker):
     return mocker.patch(f"{MODULE}.requests.Session").return_value
 
@@ -55,9 +55,29 @@ class TestTogglBase:
         assert "/endpoint" in url
 
 
+class TestTogglOrganization:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.toggl = TogglOrganization("token", 1234, 5678)
+
+    def test_init(self):
+        assert self.toggl.organization_id == 5678
+
+    def test_api_url_resource(self):
+        assert self.toggl.api_url_resource == "organizations/5678"
+
+    def test_get_users(self, mock_requests):
+        url = self.toggl.make_api_url("users")
+
+        response = self.toggl.get_users()
+
+        response.raise_for_status.assert_called_once()
+        mock_requests.get.assert_called_once_with(url, timeout=self.toggl.timeout)
+
+
 class TestTogglReports:
     @pytest.fixture(autouse=True)
-    def setup(self, mock_requests):
+    def setup(self):
         self.toggl = TogglReports("token", 1234)
 
     @pytest.fixture
@@ -113,7 +133,7 @@ class TestTogglReports:
 
 class TestTogglWorkspace:
     @pytest.fixture(autouse=True)
-    def setup(self, mock_requests):
+    def setup(self):
         self.toggl = TogglWorkspace("token", 1234)
 
     def test_api_url_resource(self):

--- a/tests/commands/test_info.py
+++ b/tests/commands/test_info.py
@@ -1,7 +1,7 @@
 import pytest
 
-from compiler_admin import RESULT_SUCCESS, __version__
-from compiler_admin.commands.info import info, __name__ as MODULE
+from compiler_admin import Result, __version__
+from compiler_admin.commands.info import __name__ as MODULE, info
 
 
 @pytest.fixture
@@ -17,7 +17,7 @@ def mock_google_CallGYBCommand(mock_google_CallGYBCommand):
 def test_info(cli_runner, mock_google_CallGAMCommand, mock_google_CallGYBCommand):
     result = cli_runner.invoke(info)
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     assert f"compiler-admin, version {__version__}" in result.output
     assert mock_google_CallGAMCommand.call_count > 0
     mock_google_CallGYBCommand.assert_called_once()

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -1,7 +1,7 @@
 import pytest
 
-from compiler_admin import RESULT_SUCCESS
-from compiler_admin.commands.init import _clean_config_dir, init, __name__ as MODULE
+from compiler_admin import Result
+from compiler_admin.commands.init import __name__ as MODULE, _clean_config_dir, init
 
 
 @pytest.fixture
@@ -55,7 +55,7 @@ def test_clean_config_dir(mocker, mock_GAM_CONFIG_PATH, mock_rmtree):
 def test_init_default(cli_runner, mock_clean_config_dir, mock_google_CallGAMCommand, mock_subprocess_call):
     result = cli_runner.invoke(init, ["username"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     assert mock_clean_config_dir.call_count == 0
     assert mock_google_CallGAMCommand.call_count == 0
     assert mock_subprocess_call.call_count == 0
@@ -64,7 +64,7 @@ def test_init_default(cli_runner, mock_clean_config_dir, mock_google_CallGAMComm
 def test_init_gam(cli_runner, mock_GAM_CONFIG_PATH, mock_clean_config_dir, mock_google_CallGAMCommand):
     result = cli_runner.invoke(init, ["--gam", "username"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_clean_config_dir.assert_called_once()
     assert mock_GAM_CONFIG_PATH in mock_clean_config_dir.call_args.args
     assert mock_google_CallGAMCommand.call_count > 0
@@ -73,7 +73,7 @@ def test_init_gam(cli_runner, mock_GAM_CONFIG_PATH, mock_clean_config_dir, mock_
 def test_init_gyb(cli_runner, mock_GYB_CONFIG_PATH, mock_clean_config_dir, mock_subprocess_call):
     result = cli_runner.invoke(init, ["--gyb", "username"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_clean_config_dir.assert_called_once()
     assert mock_GYB_CONFIG_PATH in mock_clean_config_dir.call_args.args
     assert mock_subprocess_call.call_count > 0

--- a/tests/commands/time/test_convert.py
+++ b/tests/commands/time/test_convert.py
@@ -1,7 +1,7 @@
 import pytest
 
-from compiler_admin import RESULT_SUCCESS
-from compiler_admin.commands.time.convert import __name__ as MODULE, TIME_SERVICES, _get_source_converter, convert
+from compiler_admin import Result
+from compiler_admin.commands.time.convert import TIME_SERVICES, __name__ as MODULE, _get_source_converter, convert
 from compiler_admin.services.harvest import HarvestTime
 from compiler_admin.services.toggl import TogglTime
 
@@ -39,7 +39,7 @@ def test_convert(cli_runner, mock_get_source_converter):
         convert, ["--input", "input", "--output", "output", "--client", "client", "--from", "harvest", "--to", "toggl"]
     )
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_get_source_converter.assert_called_once_with("harvest", "toggl")
     mock_get_source_converter.return_value.assert_called_once_with(
         source_path="input", output_path="output", client_name="client"

--- a/tests/commands/time/test_download.py
+++ b/tests/commands/time/test_download.py
@@ -2,8 +2,8 @@ from datetime import datetime
 
 import pytest
 
-from compiler_admin import RESULT_SUCCESS
-from compiler_admin.commands.time.download import __name__ as MODULE, TZINFO, download, prior_month_end, prior_month_start
+from compiler_admin import Result
+from compiler_admin.commands.time.download import TZINFO, __name__ as MODULE, download, prior_month_end, prior_month_start
 from compiler_admin.services.toggl import TogglTime
 
 
@@ -65,7 +65,7 @@ def test_download(cli_runner, mock_local_now, mock_time_download):
 
     result = cli_runner.invoke(download, args)
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_time_download.assert_called_once_with(
         start_date=mock_local_now,
         end_date=mock_local_now,
@@ -84,7 +84,7 @@ def test_download_default(cli_runner, mock_time_download):
 
     result = cli_runner.invoke(download, [])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_time_download.assert_called_once()
     call = mock_time_download.mock_calls[0]
 
@@ -111,7 +111,7 @@ def test_download_client_envvar(cli_runner, monkeypatch, mock_time_download):
 
     result = cli_runner.invoke(download, [])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_time_download.assert_called_once()
     call = mock_time_download.mock_calls[0]
     assert call.kwargs["client_ids"] == (1234,)
@@ -120,7 +120,7 @@ def test_download_client_envvar(cli_runner, monkeypatch, mock_time_download):
 def test_download_all(cli_runner, mock_time_download):
     result = cli_runner.invoke(download, ["--all"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_time_download.assert_called_once()
     call = mock_time_download.mock_calls[0]
     assert "billable" not in call.kwargs

--- a/tests/commands/time/test_lock.py
+++ b/tests/commands/time/test_lock.py
@@ -3,8 +3,8 @@ from datetime import date, datetime, timedelta
 import pytest
 from click.testing import CliRunner
 
-from compiler_admin import RESULT_SUCCESS
-from compiler_admin.commands.time.lock import lock, TogglTime
+from compiler_admin import Result
+from compiler_admin.commands.time.lock import TogglTime, lock
 
 
 @pytest.fixture
@@ -16,7 +16,7 @@ def test_lock_default_date(mock_lock_time_entries):
     runner = CliRunner()
     result = runner.invoke(lock)
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     today = date.today()
     first_day_of_current_month = today.replace(day=1)
     lock_date = first_day_of_current_month - timedelta(days=1)
@@ -28,6 +28,6 @@ def test_lock_with_date(mock_lock_time_entries):
     lock_date_str = "2025-10-11"
     result = runner.invoke(lock, ["--date", lock_date_str])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     lock_date = datetime.strptime(lock_date_str, "%Y-%m-%d")
     mock_lock_time_entries.assert_called_once_with(lock_date)

--- a/tests/commands/user/test_backupcodes.py
+++ b/tests/commands/user/test_backupcodes.py
@@ -1,7 +1,7 @@
 import pytest
 
-from compiler_admin import RESULT_FAILURE, RESULT_SUCCESS
-from compiler_admin.commands.user.backupcodes import backupcodes, __name__ as MODULE
+from compiler_admin import Result
+from compiler_admin.commands.user.backupcodes import __name__ as MODULE, backupcodes
 
 
 @pytest.fixture
@@ -19,7 +19,7 @@ def test_backupcodes_user_does_not_exist(cli_runner, mock_google_user_exists, mo
 
     result = cli_runner.invoke(backupcodes, ["username"])
 
-    assert result.exit_code == RESULT_FAILURE
+    assert result.exit_code == Result.FAILURE
     mock_get_backup_codes.assert_not_called()
 
 
@@ -29,5 +29,5 @@ def test_backupcodes_user_exists(cli_runner, mock_google_user_exists, mock_get_b
 
     result = cli_runner.invoke(backupcodes, ["username"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_get_backup_codes.assert_called_once()

--- a/tests/commands/user/test_convert.py
+++ b/tests/commands/user/test_convert.py
@@ -1,7 +1,7 @@
 import pytest
 
-from compiler_admin import RESULT_SUCCESS
-from compiler_admin.commands.user.convert import convert, __name__ as MODULE
+from compiler_admin import Result
+from compiler_admin.commands.user.convert import __name__ as MODULE, convert
 
 
 @pytest.fixture
@@ -69,7 +69,7 @@ def test_convert_user_does_not_exists(cli_runner, mock_google_user_exists, mock_
 
     result = cli_runner.invoke(convert, ["username", "staff"])
 
-    assert result.exit_code != RESULT_SUCCESS
+    assert result.exit_code != Result.SUCCESS
     assert mock_google_move_user_ou.call_count == 0
 
 
@@ -77,7 +77,7 @@ def test_convert_user_does_not_exists(cli_runner, mock_google_user_exists, mock_
 def test_convert_user_exists_bad_account_type(cli_runner, mock_google_move_user_ou):
     result = cli_runner.invoke(convert, ["username", "bad_account_type"])
 
-    assert result.exit_code != RESULT_SUCCESS
+    assert result.exit_code != Result.SUCCESS
     assert mock_google_move_user_ou.call_count == 0
 
 
@@ -87,7 +87,7 @@ def test_convert_user_exists_bad_account_type(cli_runner, mock_google_move_user_
 def test_convert_contractor(cli_runner, mock_google_move_user_ou):
     result = cli_runner.invoke(convert, ["username", "contractor"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_google_move_user_ou.assert_called_once()
 
 
@@ -95,7 +95,7 @@ def test_convert_contractor(cli_runner, mock_google_move_user_ou):
 def test_convert_contractor_user_is_partner(cli_runner, mock_google_remove_user_from_group, mock_google_move_user_ou):
     result = cli_runner.invoke(convert, ["username", "contractor"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     assert mock_google_remove_user_from_group.call_count == 2
     mock_google_move_user_ou.assert_called_once()
 
@@ -104,7 +104,7 @@ def test_convert_contractor_user_is_partner(cli_runner, mock_google_remove_user_
 def test_convert_contractor_user_is_staff(cli_runner, mock_google_remove_user_from_group, mock_google_move_user_ou):
     result = cli_runner.invoke(convert, ["username", "contractor"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_google_remove_user_from_group.assert_called_once()
     mock_google_move_user_ou.assert_called_once()
 
@@ -115,7 +115,7 @@ def test_convert_contractor_user_is_staff(cli_runner, mock_google_remove_user_fr
 def test_convert_staff(cli_runner, mock_google_add_user_to_group, mock_google_move_user_ou):
     result = cli_runner.invoke(convert, ["username", "staff"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_google_add_user_to_group.assert_called_once()
     mock_google_move_user_ou.assert_called_once()
 
@@ -126,7 +126,7 @@ def test_convert_staff_user_is_partner(
 ):
     result = cli_runner.invoke(convert, ["username", "staff"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_google_remove_user_from_group.assert_called_once()
     mock_google_add_user_to_group.assert_called_once()
     mock_google_move_user_ou.assert_called_once()
@@ -136,7 +136,7 @@ def test_convert_staff_user_is_partner(
 def test_convert_staff_user_is_staff(cli_runner, mock_google_add_user_to_group, mock_google_move_user_ou):
     result = cli_runner.invoke(convert, ["username", "staff"])
 
-    assert result.exit_code != RESULT_SUCCESS
+    assert result.exit_code != Result.SUCCESS
     assert mock_google_add_user_to_group.call_count == 0
     assert mock_google_move_user_ou.call_count == 0
 
@@ -147,7 +147,7 @@ def test_convert_staff_user_is_staff(cli_runner, mock_google_add_user_to_group, 
 def test_convert_partner(cli_runner, mock_google_add_user_to_group, mock_google_move_user_ou):
     result = cli_runner.invoke(convert, ["username", "partner"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     assert mock_google_add_user_to_group.call_count == 2
     mock_google_move_user_ou.assert_called_once()
 
@@ -156,7 +156,7 @@ def test_convert_partner(cli_runner, mock_google_add_user_to_group, mock_google_
 def test_convert_partner_user_is_partner(cli_runner, mock_google_add_user_to_group, mock_google_move_user_ou):
     result = cli_runner.invoke(convert, ["username", "partner"])
 
-    assert result != RESULT_SUCCESS
+    assert result != Result.SUCCESS
     assert mock_google_add_user_to_group.call_count == 0
     assert mock_google_move_user_ou.call_count == 0
 
@@ -165,6 +165,6 @@ def test_convert_partner_user_is_partner(cli_runner, mock_google_add_user_to_gro
 def test_convert_partner_user_is_staff(cli_runner, mock_google_add_user_to_group, mock_google_move_user_ou):
     result = cli_runner.invoke(convert, ["username", "partner"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_google_add_user_to_group.assert_called_once()
     mock_google_move_user_ou.assert_called_once()

--- a/tests/commands/user/test_create.py
+++ b/tests/commands/user/test_create.py
@@ -1,7 +1,7 @@
 import pytest
 
-from compiler_admin import RESULT_SUCCESS
-from compiler_admin.commands.user.create import create, __name__ as MODULE
+from compiler_admin import Result
+from compiler_admin.commands.user.create import __name__ as MODULE, create
 from compiler_admin.services.google import USER_HELLO
 
 
@@ -25,7 +25,7 @@ def test_create_user_exists(cli_runner, mock_google_user_exists):
 
     result = cli_runner.invoke(create, ["username"])
 
-    assert result.exit_code != RESULT_SUCCESS
+    assert result.exit_code != Result.SUCCESS
 
 
 def test_create_user_does_not_exists(
@@ -35,7 +35,7 @@ def test_create_user_does_not_exists(
 
     result = cli_runner.invoke(create, ["username"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
 
     mock_google_CallGAMCommand.assert_called_once()
     call_args = " ".join(mock_google_CallGAMCommand.call_args[0][0])
@@ -50,7 +50,7 @@ def test_create_user_notify(cli_runner, mock_google_user_exists, mock_google_Cal
 
     result = cli_runner.invoke(create, ["--notify", "notification@example.com", "username"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
 
     mock_google_CallGAMCommand.assert_called_once()
     call_args = " ".join(mock_google_CallGAMCommand.call_args[0][0])
@@ -66,7 +66,7 @@ def test_create_user_extras(cli_runner, mock_google_user_exists, mock_google_Cal
 
     result = cli_runner.invoke(create, ["username", "extra1", "extra2"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
 
     mock_google_CallGAMCommand.assert_called_once()
     call_args = " ".join(mock_google_CallGAMCommand.call_args[0][0])

--- a/tests/commands/user/test_deactivate.py
+++ b/tests/commands/user/test_deactivate.py
@@ -1,7 +1,7 @@
 import pytest
 
-from compiler_admin import RESULT_FAILURE, RESULT_SUCCESS
-from compiler_admin.commands.user.deactivate import deactivate, __name__ as MODULE
+from compiler_admin import Result
+from compiler_admin.commands.user.deactivate import __name__ as MODULE, deactivate
 from compiler_admin.services.google import OU_ALUMNI
 
 
@@ -45,7 +45,7 @@ def test_deactivate_user_does_not_exists(cli_runner, mock_google_user_exists, mo
 
     result = cli_runner.invoke(deactivate, ["username"])
 
-    assert result.exit_code == RESULT_FAILURE
+    assert result.exit_code == Result.FAILURE
     assert result.exception
     assert "User does not exist: username@compiler.la" in result.output
     mock_google_CallGAMCommand.assert_not_called()
@@ -59,7 +59,7 @@ def test_deactivate_confirm_yes(
 
     result = cli_runner.invoke(deactivate, ["username"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_google_CallGAMCommand.assert_called()
     mock_google_move_user_ou.assert_called_once_with("username@compiler.la", OU_ALUMNI)
 
@@ -72,7 +72,7 @@ def test_deactivate_confirm_no(
 
     result = cli_runner.invoke(deactivate, ["username"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_google_CallGAMCommand.assert_not_called()
     mock_google_move_user_ou.assert_not_called()
 
@@ -84,6 +84,6 @@ def test_deactivate_force(
 
     result = cli_runner.invoke(deactivate, ["--force", "username"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_google_CallGAMCommand.assert_called()
     mock_google_move_user_ou.assert_called_once_with("username@compiler.la", OU_ALUMNI)

--- a/tests/commands/user/test_delete.py
+++ b/tests/commands/user/test_delete.py
@@ -1,7 +1,7 @@
 import pytest
 
-from compiler_admin import RESULT_SUCCESS
-from compiler_admin.commands.user.delete import delete, __name__ as MODULE
+from compiler_admin import Result
+from compiler_admin.commands.user.delete import __name__ as MODULE, delete
 
 
 @pytest.fixture
@@ -30,7 +30,7 @@ def test_delete_confirm_yes(cli_runner, mock_google_user_exists, mock_google_Cal
 
     result = cli_runner.invoke(delete, ["username"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_google_CallGAMCommand.assert_called_once()
     call_args = mock_google_CallGAMCommand.call_args.args[0]
     assert "delete" in call_args
@@ -44,7 +44,7 @@ def test_delete_confirm_no(cli_runner, mock_google_user_exists, mock_google_Call
 
     result = cli_runner.invoke(delete, ["username"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_google_CallGAMCommand.assert_not_called()
 
 
@@ -53,5 +53,5 @@ def test_delete_user_does_not_exist(cli_runner, mock_google_user_exists, mock_go
 
     result = cli_runner.invoke(delete, ["username"])
 
-    assert result.exit_code != RESULT_SUCCESS
+    assert result.exit_code != Result.SUCCESS
     assert mock_google_CallGAMCommand.call_count == 0

--- a/tests/commands/user/test_init.py
+++ b/tests/commands/user/test_init.py
@@ -11,6 +11,7 @@ from compiler_admin.commands.user import user
         "create",
         "deactivate",
         "delete",
+        "ls",
         "offboard",
         "reactivate",
         "reset",

--- a/tests/commands/user/test_ls.py
+++ b/tests/commands/user/test_ls.py
@@ -1,7 +1,9 @@
+import json
+
 import pytest
 
-from compiler_admin import Result
-from compiler_admin.commands.user.ls import USER_SYSTEMS, __name__ as MODULE, ls, ls_google, ls_toggl
+from compiler_admin import Format, Result
+from compiler_admin.commands.user.ls import FORMATS, USER_SYSTEMS, __name__ as MODULE, ls, ls_google, ls_toggl
 
 
 @pytest.fixture
@@ -35,7 +37,7 @@ def test_ls_default(cli_runner, mock_ls_google, mock_ls_toggl):
     result = cli_runner.invoke(ls, args)
 
     assert result.exit_code == Result.SUCCESS
-    mock_ls_google.assert_called_once_with(inactive=False)
+    mock_ls_google.assert_called_once_with(inactive=False, format=Format.BASIC)
     mock_ls_toggl.assert_not_called()
 
 
@@ -71,7 +73,7 @@ def test_ls__inactive(cli_runner, mock_ls_google):
     result = cli_runner.invoke(ls, args)
 
     assert result.exit_code == Result.SUCCESS
-    mock_ls_google.assert_called_once_with(inactive=True)
+    mock_ls_google.assert_called_once_with(inactive=True, format=Format.BASIC)
 
 
 def test_ls__inactive__system_toggl(cli_runner, mock_ls_toggl):
@@ -79,13 +81,20 @@ def test_ls__inactive__system_toggl(cli_runner, mock_ls_toggl):
     result = cli_runner.invoke(ls, args)
 
     assert result.exit_code == Result.SUCCESS
-    mock_ls_toggl.assert_called_once_with(inactive=True)
+    mock_ls_toggl.assert_called_once_with(inactive=True, format=Format.BASIC)
 
 
 def test_ls_google(mock_google_get_users):
     ls_google()
 
     mock_google_get_users.assert_called_once()
+
+
+@pytest.mark.parametrize("format", set(FORMATS.values()))
+def test_ls_google__format(mock_google_get_users, format):
+    ls_google(format=format)
+
+    mock_google_get_users.assert_called_once_with(inactive=False, format=format)
 
 
 def test_ls_toggl__default(mock_toggl_api):
@@ -98,3 +107,79 @@ def test_ls_toggl__inactive(mock_toggl_api):
     ls_toggl(inactive=True)
 
     mock_toggl_api.get_organization_users.assert_called_once_with(inactive=True)
+
+
+MOCK_USERS = [
+    {
+        "email": "email1@example.com",
+        "name": "name1",
+        "id": "id1",
+        "user_id": "user1",
+        "role_id": "role1",
+        "organization_id": 5678,
+        "inactive": False,
+        "joined": True,
+        "can_edit_email": False,
+        "2fa_enabled": True,
+        "avatar_url": "https://example.com/users/1",
+        "extra": "extra1",
+    },
+    {
+        "email": "email2@example.com",
+        "name": "name2",
+        "id": "id2",
+        "user_id": "user2",
+        "role_id": "role2",
+        "organization_id": 5678,
+        "inactive": False,
+        "joined": True,
+        "can_edit_email": False,
+        "2fa_enabled": True,
+        "avatar_url": "https://example.com/users/2",
+        "extra": "extra1",
+    },
+]
+
+
+@pytest.mark.parametrize(
+    "format,expected_out,not_expected_out",
+    [
+        (Format.BASIC, ["Got 2 Users", "email\n", "email1", "email2"], ["name1", "name2"]),
+        (
+            Format.CSV,
+            [
+                "Got 2 Users",
+                "email,name,id,user_id,role_id,organization_id,inactive,joined,can_edit_email,2fa_enabled,avatar_url\n",
+                "email1",
+                "email2",
+                "name1",
+                "name2",
+                "id1",
+                "id2",
+                "user1",
+                "user2",
+                "role1",
+                "role2",
+                "5678",
+                "https://example.com/users/1",
+                "https://example.com/users/2",
+            ],
+            ["extra1", "extra2"],
+        ),
+        (
+            Format.JSON,
+            [json.dumps(MOCK_USERS, indent=2)],
+            [],
+        ),
+    ],
+)
+def test_ls__format(mock_toggl_api, capfd, format, expected_out, not_expected_out):
+    mock_toggl_api.get_organization_users.return_value = MOCK_USERS
+
+    ls_toggl(format=format)
+    captured = capfd.readouterr()
+
+    for item in expected_out:
+        assert item in captured.out
+    for item in not_expected_out:
+        assert item not in captured.out

--- a/tests/commands/user/test_ls.py
+++ b/tests/commands/user/test_ls.py
@@ -1,7 +1,7 @@
 import pytest
 
 from compiler_admin import RESULT_SUCCESS
-from compiler_admin.commands.user.ls import __name__ as MODULE, ls, ls_google
+from compiler_admin.commands.user.ls import USER_SYSTEMS, __name__ as MODULE, ls, ls_google, ls_toggl
 
 
 @pytest.fixture
@@ -10,35 +10,69 @@ def mock_google_CallGAMCommand(mock_google_CallGAMCommand):
 
 
 @pytest.fixture
-def mock_ls_google(mocker):
-    return mocker.patch(f"{MODULE}.ls_google")
+def mock_toggl_api(mocker):
+    mock = mocker.patch(f"{MODULE}.TogglUsers").return_value
+    mock.get_organization_users.return_value = {"user": "name"}
+    return mock
 
 
-def test_ls__system_default(cli_runner, mock_ls_google):
+@pytest.fixture
+def mock_ls_google(mocker, monkeypatch):
+    mock = mocker.patch(f"{MODULE}.ls_google")
+    monkeypatch.setitem(USER_SYSTEMS, "google", mock)
+    return mock
+
+
+@pytest.fixture
+def mock_ls_toggl(mocker, monkeypatch):
+    mock = mocker.patch(f"{MODULE}.ls_toggl")
+    monkeypatch.setitem(USER_SYSTEMS, "toggl", mock)
+    return mock
+
+
+def test_ls__system_default(cli_runner, mock_ls_google, mock_ls_toggl):
     args = []
     result = cli_runner.invoke(ls, args)
 
     assert result.exit_code == RESULT_SUCCESS
     mock_ls_google.assert_called_once()
+    mock_ls_toggl.assert_not_called()
 
 
-def test_ls__system_google(cli_runner, mock_ls_google):
-    args = ["--system", "google"]
+def test_ls__system_google(cli_runner, mock_ls_google, mock_ls_toggl):
+    args = ["google"]
     result = cli_runner.invoke(ls, args)
 
     assert result.exit_code == RESULT_SUCCESS
     mock_ls_google.assert_called_once()
+    mock_ls_toggl.assert_not_called()
 
 
-def test_ls__system_unknown(cli_runner, mock_ls_google):
-    args = ["--system", "unknown"]
+def test_ls__system_toggl(cli_runner, mock_ls_google, mock_ls_toggl):
+    args = ["toggl"]
+    result = cli_runner.invoke(ls, args)
+
+    assert result.exit_code == RESULT_SUCCESS
+    mock_ls_google.assert_not_called()
+    mock_ls_toggl.assert_called_once()
+
+
+def test_ls__system_unknown(cli_runner, mock_ls_google, mock_ls_toggl):
+    args = ["unknown"]
     result = cli_runner.invoke(ls, args)
 
     assert result.exit_code != RESULT_SUCCESS
     mock_ls_google.assert_not_called()
+    mock_ls_toggl.assert_not_called()
 
 
 def test_ls_google(mock_google_CallGAMCommand):
     ls_google()
 
     mock_google_CallGAMCommand.assert_called_once()
+
+
+def test_ls_toggl(mock_toggl_api):
+    ls_toggl()
+
+    mock_toggl_api.get_organization_users.assert_called_once()

--- a/tests/commands/user/test_ls.py
+++ b/tests/commands/user/test_ls.py
@@ -1,7 +1,7 @@
 import pytest
 
 from compiler_admin import RESULT_SUCCESS
-from compiler_admin.commands.user.ls import __name__ as MODULE, ls
+from compiler_admin.commands.user.ls import __name__ as MODULE, ls, ls_google
 
 
 @pytest.fixture
@@ -9,9 +9,36 @@ def mock_google_CallGAMCommand(mock_google_CallGAMCommand):
     return mock_google_CallGAMCommand(MODULE)
 
 
-def test_ls(cli_runner, mock_google_CallGAMCommand):
+@pytest.fixture
+def mock_ls_google(mocker):
+    return mocker.patch(f"{MODULE}.ls_google")
+
+
+def test_ls__system_default(cli_runner, mock_ls_google):
     args = []
     result = cli_runner.invoke(ls, args)
 
     assert result.exit_code == RESULT_SUCCESS
+    mock_ls_google.assert_called_once()
+
+
+def test_ls__system_google(cli_runner, mock_ls_google):
+    args = ["--system", "google"]
+    result = cli_runner.invoke(ls, args)
+
+    assert result.exit_code == RESULT_SUCCESS
+    mock_ls_google.assert_called_once()
+
+
+def test_ls__system_unknown(cli_runner, mock_ls_google):
+    args = ["--system", "unknown"]
+    result = cli_runner.invoke(ls, args)
+
+    assert result.exit_code != RESULT_SUCCESS
+    mock_ls_google.assert_not_called()
+
+
+def test_ls_google(mock_google_CallGAMCommand):
+    ls_google()
+
     mock_google_CallGAMCommand.assert_called_once()

--- a/tests/commands/user/test_ls.py
+++ b/tests/commands/user/test_ls.py
@@ -5,8 +5,8 @@ from compiler_admin.commands.user.ls import USER_SYSTEMS, __name__ as MODULE, ls
 
 
 @pytest.fixture
-def mock_google_CallGAMCommand(mock_google_CallGAMCommand):
-    return mock_google_CallGAMCommand(MODULE)
+def mock_google_get_users(mocker):
+    return mocker.patch(f"{MODULE}.get_users")
 
 
 @pytest.fixture
@@ -82,10 +82,10 @@ def test_ls__inactive__system_toggl(cli_runner, mock_ls_toggl):
     mock_ls_toggl.assert_called_once_with(inactive=True)
 
 
-def test_ls_google(mock_google_CallGAMCommand):
+def test_ls_google(mock_google_get_users):
     ls_google()
 
-    mock_google_CallGAMCommand.assert_called_once()
+    mock_google_get_users.assert_called_once()
 
 
 def test_ls_toggl(mock_toggl_api):

--- a/tests/commands/user/test_ls.py
+++ b/tests/commands/user/test_ls.py
@@ -12,7 +12,7 @@ def mock_google_CallGAMCommand(mock_google_CallGAMCommand):
 @pytest.fixture
 def mock_toggl_api(mocker):
     mock = mocker.patch(f"{MODULE}.TogglUsers").return_value
-    mock.get_organization_users.return_value = {"user": "name"}
+    mock.get_organization_users.return_value = [{"email": "user@example.com"}]
     return mock
 
 
@@ -30,12 +30,12 @@ def mock_ls_toggl(mocker, monkeypatch):
     return mock
 
 
-def test_ls__system_default(cli_runner, mock_ls_google, mock_ls_toggl):
+def test_ls_default(cli_runner, mock_ls_google, mock_ls_toggl):
     args = []
     result = cli_runner.invoke(ls, args)
 
     assert result.exit_code == RESULT_SUCCESS
-    mock_ls_google.assert_called_once()
+    mock_ls_google.assert_called_once_with(inactive=False)
     mock_ls_toggl.assert_not_called()
 
 
@@ -64,6 +64,22 @@ def test_ls__system_unknown(cli_runner, mock_ls_google, mock_ls_toggl):
     assert result.exit_code != RESULT_SUCCESS
     mock_ls_google.assert_not_called()
     mock_ls_toggl.assert_not_called()
+
+
+def test_ls__inactive(cli_runner, mock_ls_google):
+    args = ["--inactive"]
+    result = cli_runner.invoke(ls, args)
+
+    assert result.exit_code == RESULT_SUCCESS
+    mock_ls_google.assert_called_once_with(inactive=True)
+
+
+def test_ls__inactive__system_toggl(cli_runner, mock_ls_toggl):
+    args = ["--inactive", "toggl"]
+    result = cli_runner.invoke(ls, args)
+
+    assert result.exit_code == RESULT_SUCCESS
+    mock_ls_toggl.assert_called_once_with(inactive=True)
 
 
 def test_ls_google(mock_google_CallGAMCommand):

--- a/tests/commands/user/test_ls.py
+++ b/tests/commands/user/test_ls.py
@@ -1,6 +1,6 @@
 import pytest
 
-from compiler_admin import RESULT_SUCCESS
+from compiler_admin import Result
 from compiler_admin.commands.user.ls import USER_SYSTEMS, __name__ as MODULE, ls, ls_google, ls_toggl
 
 
@@ -34,7 +34,7 @@ def test_ls_default(cli_runner, mock_ls_google, mock_ls_toggl):
     args = []
     result = cli_runner.invoke(ls, args)
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_ls_google.assert_called_once_with(inactive=False)
     mock_ls_toggl.assert_not_called()
 
@@ -43,7 +43,7 @@ def test_ls__system_google(cli_runner, mock_ls_google, mock_ls_toggl):
     args = ["google"]
     result = cli_runner.invoke(ls, args)
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_ls_google.assert_called_once()
     mock_ls_toggl.assert_not_called()
 
@@ -52,7 +52,7 @@ def test_ls__system_toggl(cli_runner, mock_ls_google, mock_ls_toggl):
     args = ["toggl"]
     result = cli_runner.invoke(ls, args)
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_ls_google.assert_not_called()
     mock_ls_toggl.assert_called_once()
 
@@ -61,7 +61,7 @@ def test_ls__system_unknown(cli_runner, mock_ls_google, mock_ls_toggl):
     args = ["unknown"]
     result = cli_runner.invoke(ls, args)
 
-    assert result.exit_code != RESULT_SUCCESS
+    assert result.exit_code != Result.SUCCESS
     mock_ls_google.assert_not_called()
     mock_ls_toggl.assert_not_called()
 
@@ -70,7 +70,7 @@ def test_ls__inactive(cli_runner, mock_ls_google):
     args = ["--inactive"]
     result = cli_runner.invoke(ls, args)
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_ls_google.assert_called_once_with(inactive=True)
 
 
@@ -78,7 +78,7 @@ def test_ls__inactive__system_toggl(cli_runner, mock_ls_toggl):
     args = ["--inactive", "toggl"]
     result = cli_runner.invoke(ls, args)
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_ls_toggl.assert_called_once_with(inactive=True)
 
 

--- a/tests/commands/user/test_ls.py
+++ b/tests/commands/user/test_ls.py
@@ -1,0 +1,17 @@
+import pytest
+
+from compiler_admin import RESULT_SUCCESS
+from compiler_admin.commands.user.ls import __name__ as MODULE, ls
+
+
+@pytest.fixture
+def mock_google_CallGAMCommand(mock_google_CallGAMCommand):
+    return mock_google_CallGAMCommand(MODULE)
+
+
+def test_ls(cli_runner, mock_google_CallGAMCommand):
+    args = []
+    result = cli_runner.invoke(ls, args)
+
+    assert result.exit_code == RESULT_SUCCESS
+    mock_google_CallGAMCommand.assert_called_once()

--- a/tests/commands/user/test_ls.py
+++ b/tests/commands/user/test_ls.py
@@ -88,7 +88,13 @@ def test_ls_google(mock_google_get_users):
     mock_google_get_users.assert_called_once()
 
 
-def test_ls_toggl(mock_toggl_api):
+def test_ls_toggl__default(mock_toggl_api):
     ls_toggl()
 
-    mock_toggl_api.get_organization_users.assert_called_once()
+    mock_toggl_api.get_organization_users.assert_called_once_with(inactive=False)
+
+
+def test_ls_toggl__inactive(mock_toggl_api):
+    ls_toggl(inactive=True)
+
+    mock_toggl_api.get_organization_users.assert_called_once_with(inactive=True)

--- a/tests/commands/user/test_offboard.py
+++ b/tests/commands/user/test_offboard.py
@@ -1,7 +1,7 @@
 import pytest
 
-from compiler_admin import RESULT_SUCCESS
-from compiler_admin.commands.user.offboard import offboard, __name__ as MODULE
+from compiler_admin import Result
+from compiler_admin.commands.user.offboard import __name__ as MODULE, offboard
 
 
 @pytest.fixture
@@ -64,7 +64,7 @@ def test_offboard_confirm_yes(
 
     result = cli_runner.invoke(offboard, args)
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     assert mock_google_CallGAMCommand.call_count > 0
     mock_google_CallGYBCommand.assert_called_once()
     mock_NamedTemporaryFile.assert_called_once()
@@ -90,7 +90,7 @@ def test_offboard_confirm_no(
 
     result = cli_runner.invoke(offboard, ["username"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_google_CallGAMCommand.assert_not_called()
     mock_google_CallGYBCommand.assert_not_called()
 
@@ -103,7 +103,7 @@ def test_offboard_user_does_not_exist(cli_runner, mock_google_user_exists, mock_
 
     result = cli_runner.invoke(offboard, ["username"])
 
-    assert result.exit_code != RESULT_SUCCESS
+    assert result.exit_code != Result.SUCCESS
     assert mock_google_CallGAMCommand.call_count == 0
 
 
@@ -114,6 +114,6 @@ def test_offboard_alias_user_does_not_exist(cli_runner, mock_google_user_exists,
 
     result = cli_runner.invoke(offboard, ["--alias", "alias_username", "username"])
 
-    assert result.exit_code != RESULT_SUCCESS
+    assert result.exit_code != Result.SUCCESS
     assert mock_google_user_exists.call_count == 2
     assert mock_google_CallGAMCommand.call_count == 0

--- a/tests/commands/user/test_reactivate.py
+++ b/tests/commands/user/test_reactivate.py
@@ -2,10 +2,9 @@ from unittest.mock import call
 
 import pytest
 
-from compiler_admin import RESULT_FAILURE, RESULT_SUCCESS
+from compiler_admin import Result
 from compiler_admin.commands.user.backupcodes import backupcodes
-from compiler_admin.commands.user.reactivate import __name__ as MODULE
-from compiler_admin.commands.user.reactivate import reactivate
+from compiler_admin.commands.user.reactivate import __name__ as MODULE, reactivate
 from compiler_admin.commands.user.reset import reset
 from compiler_admin.services.google import GROUP_STAFF, GROUP_TEAM, OU_CONTRACTORS, OU_STAFF
 
@@ -56,7 +55,7 @@ def test_reactivate_user_does_not_exist(cli_runner, mock_google_user_exists, moc
 
     result = cli_runner.invoke(reactivate, ["username"])
 
-    assert result.exit_code == RESULT_FAILURE
+    assert result.exit_code == Result.FAILURE
     assert result.exception
     assert "User does not exist: username@compiler.la" in result.output
     mock_google_CallGAMCommand.assert_not_called()
@@ -68,7 +67,7 @@ def test_reactivate_user_is_not_deactivated(cli_runner, mock_google_user_exists,
 
     result = cli_runner.invoke(reactivate, ["username"])
 
-    assert result.exit_code == RESULT_FAILURE
+    assert result.exit_code == Result.FAILURE
     assert result.exception
     assert "User is not deactivated, cannot reactivate" in result.output
 
@@ -80,7 +79,7 @@ def test_reactivate_confirm_no(cli_runner, mock_google_user_exists, mock_google_
 
     result = cli_runner.invoke(reactivate, ["username"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     assert not result.exception
     assert "Aborting reactivation" in result.output
 
@@ -99,7 +98,7 @@ def test_reactivate_confirm_yes(
 
     result = cli_runner.invoke(reactivate, ["username"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     assert not result.exception
     mock_google_add_user_to_group.assert_called_once_with("username@compiler.la", GROUP_TEAM)
     mock_google_move_user_ou.assert_called_once_with("username@compiler.la", OU_CONTRACTORS)
@@ -119,7 +118,7 @@ def test_reactivate_force(
 
     result = cli_runner.invoke(reactivate, ["--force", "username"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     assert not result.exception
     mock_google_add_user_to_group.assert_called_once_with("username@compiler.la", GROUP_TEAM)
     mock_google_move_user_ou.assert_called_once_with("username@compiler.la", OU_CONTRACTORS)
@@ -139,7 +138,7 @@ def test_reactivate_staff(
 
     result = cli_runner.invoke(reactivate, ["--force", "--staff", "username"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     assert not result.exception
     mock_google_add_user_to_group.assert_has_calls(
         [call("username@compiler.la", GROUP_TEAM), call("username@compiler.la", GROUP_STAFF)]
@@ -162,7 +161,7 @@ def test_reactivate_recovery_info(
         reactivate, ["--force", "--recovery-email=foo@bar.com", "--recovery-phone=555-555-5555", "username"]
     )
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     assert not result.exception
     mock_google_CallGAMCommand.assert_has_calls(
         [

--- a/tests/commands/user/test_reset.py
+++ b/tests/commands/user/test_reset.py
@@ -1,7 +1,7 @@
 import pytest
 
-from compiler_admin import RESULT_SUCCESS
-from compiler_admin.commands.user.reset import reset, __name__ as MODULE
+from compiler_admin import Result
+from compiler_admin.commands.user.reset import __name__ as MODULE, reset
 from compiler_admin.services.google import USER_HELLO
 
 
@@ -35,7 +35,7 @@ def test_reset_user_does_not_exist(cli_runner, mock_google_user_exists):
 
     result = cli_runner.invoke(reset, ["username"])
 
-    assert result.exit_code != RESULT_SUCCESS
+    assert result.exit_code != Result.SUCCESS
 
 
 @pytest.mark.usefixtures("mock_input_yes")
@@ -44,7 +44,7 @@ def test_reset_confirm_yes(cli_runner, mock_google_user_exists, mock_google_Call
 
     result = cli_runner.invoke(reset, ["username"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_google_CallGAMCommand.assert_called_once()
     mock_commands_signout.callback.assert_called_once()
 
@@ -55,7 +55,7 @@ def test_reset_confirm_no(cli_runner, mock_google_user_exists, mock_google_CallG
 
     result = cli_runner.invoke(reset, ["username"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_google_CallGAMCommand.assert_not_called()
     mock_commands_signout.callback.assert_not_called()
 
@@ -65,7 +65,7 @@ def test_reset_user_exists(cli_runner, mock_google_user_exists, mock_google_Call
 
     result = cli_runner.invoke(reset, ["--force", "username"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_google_CallGAMCommand.assert_called_once()
     call_args = " ".join(mock_google_CallGAMCommand.call_args[0][0])
     assert "update user" in call_args
@@ -78,7 +78,7 @@ def test_reset_notify(cli_runner, mock_google_user_exists, mock_google_CallGAMCo
 
     result = cli_runner.invoke(reset, ["--force", "--notify", "notification@example.com", "username"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_google_CallGAMCommand.assert_called_once()
     call_args = " ".join(mock_google_CallGAMCommand.call_args[0][0])
     assert "update user" in call_args

--- a/tests/commands/user/test_restore.py
+++ b/tests/commands/user/test_restore.py
@@ -1,7 +1,7 @@
 import pytest
 
-from compiler_admin import RESULT_SUCCESS
-from compiler_admin.commands.user.restore import restore, __name__ as MODULE
+from compiler_admin import Result
+from compiler_admin.commands.user.restore import __name__ as MODULE, restore
 
 
 @pytest.fixture
@@ -19,7 +19,7 @@ def test_restore_backup_exists(cli_runner, mock_Path_exists, mock_google_CallGYB
 
     result = cli_runner.invoke(restore, ["username"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_google_CallGYBCommand.assert_called_once()
 
 
@@ -28,5 +28,5 @@ def test_restore_backup_does_not_exist(cli_runner, mock_Path_exists, mock_google
 
     result = cli_runner.invoke(restore, ["username"])
 
-    assert result.exit_code != RESULT_SUCCESS
+    assert result.exit_code != Result.SUCCESS
     assert mock_google_CallGYBCommand.call_count == 0

--- a/tests/commands/user/test_signout.py
+++ b/tests/commands/user/test_signout.py
@@ -1,7 +1,7 @@
 import pytest
 
-from compiler_admin import RESULT_SUCCESS
-from compiler_admin.commands.user.signout import signout, __name__ as MODULE
+from compiler_admin import Result
+from compiler_admin.commands.user.signout import __name__ as MODULE, signout
 
 
 @pytest.fixture
@@ -30,7 +30,7 @@ def test_signout_confirm_yes(cli_runner, mock_google_user_exists, mock_google_Ca
 
     result = cli_runner.invoke(signout, ["username"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_google_CallGAMCommand.assert_called_once()
     call_args = mock_google_CallGAMCommand.call_args.args[0]
     assert "user" in call_args and "signout" in call_args
@@ -42,7 +42,7 @@ def test_signout_confirm_no(cli_runner, mock_google_user_exists, mock_google_Cal
 
     result = cli_runner.invoke(signout, ["username"])
 
-    assert result.exit_code == RESULT_SUCCESS
+    assert result.exit_code == Result.SUCCESS
     mock_google_CallGAMCommand.assert_not_called()
 
 
@@ -51,5 +51,5 @@ def test_signout_user_does_not_exist(cli_runner, mock_google_user_exists, mock_g
 
     result = cli_runner.invoke(signout, ["username"])
 
-    assert result.exit_code != RESULT_SUCCESS
+    assert result.exit_code != Result.SUCCESS
     mock_google_CallGAMCommand.assert_not_called()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,9 @@
 import click
-from click.testing import CliRunner
-
 import pytest
+from click.testing import CliRunner
 from pytest_socket import disable_socket
 
-from compiler_admin import RESULT_SUCCESS
+from compiler_admin import Result
 
 
 def pytest_runtest_setup():
@@ -16,13 +15,13 @@ def mock_module_name(mocker):
     """Fixture returns a function taking a name, that returns a function taking a module,
     patching the given name in the given module.
 
-    By default, the patched object is given a return_value = RESULT_SUCCESS.
+    By default, the patched object is given a return_value = ResultCodes.SUCCESS.
     """
 
     def _mock_module_name(name):
         def __mock_module_name(module):
             patched = mocker.patch(f"{module}.{name}")
-            patched.return_value = RESULT_SUCCESS
+            patched.return_value = Result.SUCCESS
             return patched
 
         return __mock_module_name
@@ -62,7 +61,7 @@ def mock_input_no(mock_input):
 
 @click.command
 def dummy_command(**kwargs):
-    return RESULT_SUCCESS
+    return Result.SUCCESS
 
 
 @pytest.fixture

--- a/tests/services/test_files.py
+++ b/tests/services/test_files.py
@@ -1,5 +1,8 @@
 import json
+from io import StringIO
+from pathlib import Path
 from tempfile import NamedTemporaryFile
+
 import pytest
 
 import compiler_admin.services.files
@@ -56,11 +59,25 @@ def test_read_csv(sample_data, sample_csv_lines, spy_pandas, temp_file):
     assert df["three"].to_list() == three
 
 
-def test_read_json(sample_data, temp_file):
+def test_read_json__buffer(sample_data):
+    f = StringIO(json.dumps(sample_data))
+
+    assert read_json(f) == sample_data
+
+
+def test_read_json__file(sample_data, temp_file):
     with open(temp_file.name, "wt") as f:
         json.dump(sample_data, f)
 
     assert read_json(temp_file.name) == sample_data
+
+
+def test_read_json__Path(sample_data, temp_file):
+    with open(temp_file.name, "wt") as f:
+        json.dump(sample_data, f)
+
+    path = Path(temp_file.name)
+    assert read_json(path) == sample_data
 
 
 def test_write_csv(sample_data, sample_csv_lines, mocker, temp_file):
@@ -76,8 +93,24 @@ def test_write_csv(sample_data, sample_csv_lines, mocker, temp_file):
         assert f.readlines() == sample_csv_lines
 
 
-def test_write_json(sample_data, temp_file):
+def test_write_json__buffer(sample_data):
+    with StringIO() as f:
+        write_json(f, sample_data)
+        f.seek(0)
+
+        assert json.load(f) == sample_data
+
+
+def test_write_json__file(sample_data, temp_file):
     write_json(temp_file.name, sample_data)
+
+    with open(temp_file.name, "rt") as f:
+        assert json.load(f) == sample_data
+
+
+def test_write_json__Path(sample_data, temp_file):
+    path = Path(temp_file.name)
+    write_json(path, sample_data)
 
     with open(temp_file.name, "rt") as f:
         assert json.load(f) == sample_data

--- a/tests/services/test_google.py
+++ b/tests/services/test_google.py
@@ -3,7 +3,7 @@ from tempfile import TemporaryFile
 
 import pytest
 
-from compiler_admin import RESULT_FAILURE, RESULT_SUCCESS
+from compiler_admin import Result
 from compiler_admin.services.google import (
     DOMAIN,
     GAM,
@@ -286,7 +286,7 @@ def test_user_exists_user_does_not_exist(mock_google_user_info):
 
 def test_user_info_user_exists(mock_gam_CallGAMCommand, mock_NamedTemporaryFile_with_readlines):
     mock_NamedTemporaryFile_with_readlines(MODULE, ["First Name:Test", "Last Name:User"])
-    mock_gam_CallGAMCommand.return_value = RESULT_SUCCESS
+    mock_gam_CallGAMCommand.return_value = Result.SUCCESS
 
     res = user_info(user_account_name("username"))
 
@@ -294,7 +294,7 @@ def test_user_info_user_exists(mock_gam_CallGAMCommand, mock_NamedTemporaryFile_
 
 
 def test_user_info_user_does_not_exists(mock_gam_CallGAMCommand):
-    mock_gam_CallGAMCommand.return_value = RESULT_FAILURE
+    mock_gam_CallGAMCommand.return_value = Result.FAILURE
 
     res = user_info(user_account_name("username"))
 

--- a/tests/services/test_google.py
+++ b/tests/services/test_google.py
@@ -3,7 +3,7 @@ from tempfile import TemporaryFile
 
 import pytest
 
-from compiler_admin import RESULT_SUCCESS, RESULT_FAILURE
+from compiler_admin import RESULT_FAILURE, RESULT_SUCCESS
 from compiler_admin.services.google import (
     DOMAIN,
     GAM,
@@ -13,13 +13,15 @@ from compiler_admin.services.google import (
     GYB,
     OU_ALUMNI,
     USER_ARCHIVE,
-    user_account_name,
     CallGAMCommand,
     CallGYBCommand,
+    __name__ as MODULE,
     add_user_to_group,
     get_backup_codes,
+    get_users,
     move_user_ou,
     remove_user_from_group,
+    user_account_name,
     user_exists,
     user_in_group,
     user_in_ou,
@@ -27,7 +29,6 @@ from compiler_admin.services.google import (
     user_is_deactivated,
     user_is_partner,
     user_is_staff,
-    __name__ as MODULE,
 )
 
 
@@ -223,6 +224,28 @@ def test_get_backup_codes_user_exists_no_codes(mocker, mock_gam_CallGAMCommand):
     assert "show" in mock_gam_CallGAMCommand.call_args_list[0].args[0]
     assert "update" in mock_gam_CallGAMCommand.call_args_list[1].args[0]
     assert res == new_codes
+
+
+def test_get_users(mock_google_CallGAMCommand):
+    get_users(kwarg1="one")
+
+    mock_google_CallGAMCommand.assert_called_once()
+    call_args = mock_google_CallGAMCommand.call_args[0]
+    command = " ".join(call_args[0])
+
+    assert "print users" in command
+    assert "issuspended false isarchived false" in command
+    assert "kwarg1 one" in command
+
+
+def test_get_users__inactive(mock_google_CallGAMCommand):
+    get_users(inactive=True)
+
+    mock_google_CallGAMCommand.assert_called_once()
+    call_args = mock_google_CallGAMCommand.call_args[0]
+    command = " ".join(call_args[0])
+
+    assert "issuspended true isarchived true" in command
 
 
 def test_move_user_ou(mock_google_CallGAMCommand):

--- a/tests/services/test_google.py
+++ b/tests/services/test_google.py
@@ -112,31 +112,29 @@ def test_user_not_in_domain(capfd):
     assert "User not in domain" in captured.out
 
 
-def test_CallGAMCommand_prepends_gam(mock_gam_CallGAMCommand):
+def test_CallGAMCommand_prepends_gam(mock_gam_CallGAMCommand, get_command_str):
     CallGAMCommand(("args",))
 
-    mock_gam_CallGAMCommand.assert_called_once()
-    call_args = mock_gam_CallGAMCommand.call_args[0][0]
-    assert call_args == (GAM, "args")
+    command = get_command_str(mock_gam_CallGAMCommand)
+
+    assert command == f"{GAM} args"
 
 
-def test_CallGAMCommand_does_not_duplicate_gam(mock_gam_CallGAMCommand):
+def test_CallGAMCommand_does_not_duplicate_gam(mock_gam_CallGAMCommand, get_command_str):
     CallGAMCommand((GAM, "args"))
 
-    mock_gam_CallGAMCommand.assert_called_once()
-    call_args = mock_gam_CallGAMCommand.call_args[0][0]
-    assert call_args == (GAM, "args")
+    command = get_command_str(mock_gam_CallGAMCommand)
+
+    assert command == f"{GAM} args"
 
 
-def test_CallGAMCommand_stdouterr_override(mock_gam_CallGAMCommand):
+def test_CallGAMCommand_stdouterr_override(mock_gam_CallGAMCommand, get_command_str):
     CallGAMCommand(("args",), stdout="override-stdout", stderr="override-stderr")
 
-    mock_gam_CallGAMCommand.assert_called_once()
-    call_args = mock_gam_CallGAMCommand.call_args[0][0]
-    call_str = " ".join(call_args)
+    command = get_command_str(mock_gam_CallGAMCommand)
 
-    assert "redirect stdout override-stdout" in call_str
-    assert "redirect stderr override-stderr" in call_str
+    assert "redirect stdout override-stdout" in command
+    assert "redirect stderr override-stderr" in command
 
 
 def test_CallGYBCommand_prepends_gyb(mock_subprocess_call):
@@ -200,15 +198,18 @@ def test_get_backup_codes_user_does_not_exist(mock_google_user_exists_no, capfd)
 
 
 @pytest.mark.usefixtures("mock_google_user_exists_yes")
-def test_get_backup_codes_user_exists_has_codes(mock_gam_CallGAMCommand, mock_NamedTemporaryFile_with_readlines):
+def test_get_backup_codes_user_exists_has_codes(
+    mock_gam_CallGAMCommand, mock_NamedTemporaryFile_with_readlines, get_command_str
+):
     username = "existent"
     codes = "12345678"
     mock_NamedTemporaryFile_with_readlines(MODULE, [codes])
 
     res = get_backup_codes(username)
 
-    assert mock_gam_CallGAMCommand.call_count == 1
-    assert "show" in mock_gam_CallGAMCommand.call_args[0][0]
+    command = get_command_str(mock_gam_CallGAMCommand)
+
+    assert "show" in command
     assert res == codes
 
 

--- a/tests/services/test_google.py
+++ b/tests/services/test_google.py
@@ -3,7 +3,7 @@ from tempfile import TemporaryFile
 
 import pytest
 
-from compiler_admin import Result
+from compiler_admin import Format, Result
 from compiler_admin.services.google import (
     DOMAIN,
     GAM,
@@ -30,6 +30,16 @@ from compiler_admin.services.google import (
     user_is_partner,
     user_is_staff,
 )
+
+
+@pytest.fixture
+def get_command_str():
+    def _get_command_str(mocked_CallGAMCommand):
+        mocked_CallGAMCommand.assert_called_once()
+        call_args = mocked_CallGAMCommand.call_args[0]
+        return " ".join([str(arg) for arg in call_args[0]])
+
+    return _get_command_str
 
 
 @pytest.fixture
@@ -226,26 +236,41 @@ def test_get_backup_codes_user_exists_no_codes(mocker, mock_gam_CallGAMCommand):
     assert res == new_codes
 
 
-def test_get_users(mock_google_CallGAMCommand):
+def test_get_users(mock_google_CallGAMCommand, get_command_str):
     get_users(kwarg1="one")
 
-    mock_google_CallGAMCommand.assert_called_once()
-    call_args = mock_google_CallGAMCommand.call_args[0]
-    command = " ".join(call_args[0])
+    command = get_command_str(mock_google_CallGAMCommand)
 
     assert "print users" in command
     assert "issuspended false isarchived false" in command
     assert "kwarg1 one" in command
 
 
-def test_get_users__inactive(mock_google_CallGAMCommand):
+def test_get_users__inactive(mock_google_CallGAMCommand, get_command_str):
     get_users(inactive=True)
 
-    mock_google_CallGAMCommand.assert_called_once()
-    call_args = mock_google_CallGAMCommand.call_args[0]
-    command = " ".join(call_args[0])
+    command = get_command_str(mock_google_CallGAMCommand)
 
     assert "issuspended true isarchived true" in command
+
+
+def test_get_users__format_csv(mock_google_CallGAMCommand, get_command_str):
+    get_users(format=Format.CSV)
+
+    command = get_command_str(mock_google_CallGAMCommand)
+
+    assert "full" in command
+
+
+@pytest.mark.parametrize("inactive,expected_in_command", ((True, "users_arch_or_susp"), (False, "users_na_ns")))
+def test_get_users__format_json(mock_google_CallGAMCommand, get_command_str, inactive, expected_in_command):
+    get_users(inactive=inactive, format=Format.JSON)
+
+    command = get_command_str(mock_google_CallGAMCommand)
+
+    assert "info users all" in command
+    assert "formatjson" in command
+    assert expected_in_command in command
 
 
 def test_move_user_ou(mock_google_CallGAMCommand):

--- a/tests/services/test_harvest.py
+++ b/tests/services/test_harvest.py
@@ -1,6 +1,6 @@
 import math
 import sys
-from datetime import timedelta, date
+from datetime import date, timedelta
 from io import StringIO
 
 import numpy as np
@@ -8,7 +8,7 @@ import pandas as pd
 import pytest
 
 import compiler_admin.services.harvest
-from compiler_admin.services.harvest import files, HarvestTime
+from compiler_admin.services.harvest import HarvestTime, files
 
 
 @pytest.fixture(autouse=True)

--- a/tests/services/test_toggl.py
+++ b/tests/services/test_toggl.py
@@ -290,11 +290,22 @@ class TestTogglUsers:
         data = {"user": "name"}
         self.users.api_organization.get_users.return_value = mocker.Mock(json=mocker.Mock(return_value=data))
         kwargs = dict(kwarg1=1, kwarg2="two")
+        call_kwargs = {**kwargs, "active_status": "active"}
 
         output = self.users.get_organization_users(**kwargs)
 
         assert output == data
-        self.users.api_organization.get_users.assert_called_once_with(**kwargs)
+        self.users.api_organization.get_users.assert_called_once_with(**call_kwargs)
+
+    def test_get_organization_users__inactive(self, mocker):
+        data = {"user": "name"}
+        self.users.api_organization.get_users.return_value = mocker.Mock(json=mocker.Mock(return_value=data))
+        call_kwargs = {"active_status": "inactive,invited"}
+
+        output = self.users.get_organization_users(inactive=True)
+
+        assert output == data
+        self.users.api_organization.get_users.assert_called_once_with(**call_kwargs)
 
     def test_get_workspace_users(self, mocker):
         data = {"user": "name"}

--- a/tests/services/test_toggl.py
+++ b/tests/services/test_toggl.py
@@ -46,14 +46,15 @@ class TestTogglTime:
     @pytest.fixture(autouse=True)
     def setup(self, mocker):
         self.time = TogglTime()
-        self.time.reports_api = mocker.Mock()
-        self.time.workspace_api = mocker.Mock()
+        self.time.api_organization = mocker.Mock()
+        self.time.api_reports = mocker.Mock()
+        self.time.api_workspace = mocker.Mock()
 
     @pytest.fixture
     def mock_toggl_detailed_time_entries(self, toggl_file):
         mock_csv_bytes = Path(toggl_file).read_bytes()
-        self.time.reports_api.detailed_time_entries.return_value.content = mock_csv_bytes
-        return self.time.reports_api.detailed_time_entries
+        self.time.api_reports.detailed_time_entries.return_value.content = mock_csv_bytes
+        return self.time.api_reports.detailed_time_entries
 
     def test_get_first_name_matching(self, mock_user_info):
         mock_user_info.return_value = {"email": {"First Name": "User"}}
@@ -263,7 +264,7 @@ class TestTogglTime:
         lock_date = datetime(2025, 10, 11)
         self.time.lock(lock_date)
 
-        self.time.workspace_api.update_preferences.assert_called_once_with(report_locked_at="2025-10-11")
+        self.time.api_workspace.update_preferences.assert_called_once_with(report_locked_at="2025-10-11")
 
     def test_summarize(self, toggl_file):
         """Test that summarize returns a valid TimeSummary object."""

--- a/tests/services/test_toggl.py
+++ b/tests/services/test_toggl.py
@@ -1,3 +1,4 @@
+import json
 import math
 import sys
 from datetime import date, datetime, timedelta
@@ -9,7 +10,7 @@ import pandas as pd
 import pytest
 
 import compiler_admin.services.toggl
-from compiler_admin.services.toggl import __name__ as MODULE, TogglTime, files
+from compiler_admin.services.toggl import TogglTime, TogglUsers, __name__ as MODULE, files
 
 
 @pytest.fixture(autouse=True)
@@ -276,3 +277,36 @@ class TestTogglTime:
         assert math.isclose(summary.total_hours, 518.32, rel_tol=1e-5)
         assert len(summary.hours_per_project) > 0
         assert len(summary.hours_per_user_project) > 0
+
+
+class TestTogglUsers:
+    @pytest.fixture(autouse=True)
+    def setup(self, mocker):
+        self.users = TogglUsers()
+        self.users.api_organization = mocker.Mock()
+        self.users.api_reports = mocker.Mock()
+        self.users.api_workspace = mocker.Mock()
+
+    def test_get_organization_users(self, mocker, spy_files):
+        data = {"user": "name"}
+        self.users.api_organization.get_users.return_value = mocker.Mock(json=mocker.Mock(return_value=data))
+        output = None
+
+        with StringIO() as output_data:
+            self.users.get_organization_users(output_data)
+            output = output_data.getvalue()
+
+        spy_files.write_json.assert_called_once()
+        assert output == json.dumps(data, indent=2)
+
+    def test_get_workspace_users(self, mocker, spy_files):
+        data = {"user": "name"}
+        self.users.api_workspace.get_users.return_value = mocker.Mock(json=mocker.Mock(return_value=data))
+        output = None
+
+        with StringIO() as output_data:
+            self.users.get_workspace_users(output_data)
+            output = output_data.getvalue()
+
+        spy_files.write_json.assert_called_once()
+        assert output == json.dumps(data, indent=2)

--- a/tests/services/test_toggl.py
+++ b/tests/services/test_toggl.py
@@ -289,14 +289,19 @@ class TestTogglUsers:
     def test_get_organization_users(self, mocker):
         data = {"user": "name"}
         self.users.api_organization.get_users.return_value = mocker.Mock(json=mocker.Mock(return_value=data))
-        output = self.users.get_organization_users()
+        kwargs = dict(kwarg1=1, kwarg2="two")
+
+        output = self.users.get_organization_users(**kwargs)
 
         assert output == data
+        self.users.api_organization.get_users.assert_called_once_with(**kwargs)
 
     def test_get_workspace_users(self, mocker):
         data = {"user": "name"}
         self.users.api_workspace.get_users.return_value = mocker.Mock(json=mocker.Mock(return_value=data))
+        kwargs = dict(kwarg1=1, kwarg2="two")
 
-        output = self.users.get_workspace_users()
+        output = self.users.get_workspace_users(**kwargs)
 
         assert output == data
+        self.users.api_workspace.get_users.assert_called_once_with(**kwargs)

--- a/tests/services/test_toggl.py
+++ b/tests/services/test_toggl.py
@@ -1,4 +1,3 @@
-import json
 import math
 import sys
 from datetime import date, datetime, timedelta
@@ -287,26 +286,17 @@ class TestTogglUsers:
         self.users.api_reports = mocker.Mock()
         self.users.api_workspace = mocker.Mock()
 
-    def test_get_organization_users(self, mocker, spy_files):
+    def test_get_organization_users(self, mocker):
         data = {"user": "name"}
         self.users.api_organization.get_users.return_value = mocker.Mock(json=mocker.Mock(return_value=data))
-        output = None
+        output = self.users.get_organization_users()
 
-        with StringIO() as output_data:
-            self.users.get_organization_users(output_data)
-            output = output_data.getvalue()
+        assert output == data
 
-        spy_files.write_json.assert_called_once()
-        assert output == json.dumps(data, indent=2)
-
-    def test_get_workspace_users(self, mocker, spy_files):
+    def test_get_workspace_users(self, mocker):
         data = {"user": "name"}
         self.users.api_workspace.get_users.return_value = mocker.Mock(json=mocker.Mock(return_value=data))
-        output = None
 
-        with StringIO() as output_data:
-            self.users.get_workspace_users(output_data)
-            output = output_data.getvalue()
+        output = self.users.get_workspace_users()
 
-        spy_files.write_json.assert_called_once()
-        assert output == json.dumps(data, indent=2)
+        assert output == data


### PR DESCRIPTION
Adds a new `user` subcommand:

```console
$ compiler-admin user ls --help
Usage: compiler-admin user ls [OPTIONS] [[google|toggl]]

  List users in the Compiler workspace.

Options:
  --inactive                      List inactive users in the system.
  -v, --verbosity [b|basic|d|detailed|j|json]
                                  How detailed the output should be.
  --help                          Show this message and exit.
```