### PR TITLE
Refactor: class-based Google services

### DIFF
--- a/compiler_admin/commands/info.py
+++ b/compiler_admin/commands/info.py
@@ -1,7 +1,7 @@
 import click
 
 from compiler_admin import __version__ as version
-from compiler_admin.services.google import CallGAMCommand, CallGYBCommand
+from compiler_admin.services.google import GoogleService
 
 
 @click.command()
@@ -9,6 +9,8 @@ def info():
     """Print information about the configured environment."""
     click.echo(f"compiler-admin, version {version}")
 
-    CallGAMCommand(("version",))
-    CallGAMCommand(("info", "domain"))
-    CallGYBCommand(("--version",))
+    google = GoogleService()
+
+    google.gam_command(("version",))
+    google.gam_command(("info", "domain"))
+    google.gyb_command(("--version",))

--- a/compiler_admin/commands/init.py
+++ b/compiler_admin/commands/init.py
@@ -5,7 +5,7 @@ from shutil import rmtree
 
 import click
 
-from compiler_admin.services.google import USER_ARCHIVE, CallGAMCommand
+from compiler_admin.services.google import GoogleUsers
 
 GAM_CONFIG_DIR = os.environ.get("GAMCFGDIR", "./.config/gam")
 GAM_CONFIG_PATH = Path(GAM_CONFIG_DIR)
@@ -33,13 +33,15 @@ def init(username: str, init_gam: bool = False, init_gyb: bool = False):
     - <https://github.com/GAM-team/GAM/wiki/How-to-Install-GAM7>
     - <https://github.com/GAM-team/got-your-back/wiki>
     """
+    google = GoogleUsers()
+
     if init_gam:
         _clean_config_dir(GAM_CONFIG_PATH)
         # GAM is already installed via pyproject.toml
-        CallGAMCommand(("config", "drive_dir", str(GAM_CONFIG_PATH), "verify"))
-        CallGAMCommand(("create", "project"))
-        CallGAMCommand(("oauth", "create"))
-        CallGAMCommand(("user", username, "check", "serviceaccount"))
+        google.gam_command(("config", "drive_dir", str(GAM_CONFIG_PATH), "verify"))
+        google.gam_command(("create", "project"))
+        google.gam_command(("oauth", "create"))
+        google.gam_command(("user", username, "check", "serviceaccount"))
 
     if init_gyb:
         _clean_config_dir(GYB_CONFIG_PATH)
@@ -54,4 +56,4 @@ def init(username: str, init_gam: bool = False, init_gyb: bool = False):
         # https://github.com/GAM-team/got-your-back/blob/main/install-gyb.sh
         #
         # use GYB_CONFIG_PATH.parent for the install directory option, otherwise we get a .config/gyb/gyb directory structure
-        subprocess.call((gyb, "-u", username, "-r", USER_ARCHIVE, "-d", str(GYB_CONFIG_PATH.parent)))
+        subprocess.call((gyb, "-u", username, "-r", google.USER_ARCHIVE, "-d", str(GYB_CONFIG_PATH.parent)))

--- a/compiler_admin/commands/ls/groups.py
+++ b/compiler_admin/commands/ls/groups.py
@@ -3,13 +3,13 @@ import pandas as pd
 
 from compiler_admin import FORMATS, Format
 from compiler_admin.services import files
-from compiler_admin.services.google import get_groups
+from compiler_admin.services.google import GoogleGroups
 from compiler_admin.services.toggl import TogglUsers
 
 
 def google(format: int = Format.BASIC, **kwargs):
     """Use GAM to print the groups in the Google Workspace."""
-    output = get_groups(format=format, **kwargs)
+    output = GoogleGroups().get(format=format, **kwargs)
     click.echo(output)
 
 

--- a/compiler_admin/commands/ls/orgs.py
+++ b/compiler_admin/commands/ls/orgs.py
@@ -1,10 +1,10 @@
 import click
 
-from compiler_admin.services.google import get_org_units
+from compiler_admin.services.google import GoogleOrgs
 
 
 @click.command()
 def orgs(**kwargs):
     """List org units in the Compiler Google workspace."""
-    output = get_org_units(**kwargs)
+    output = GoogleOrgs().get(**kwargs)
     click.echo(output)

--- a/compiler_admin/commands/ls/users.py
+++ b/compiler_admin/commands/ls/users.py
@@ -3,18 +3,18 @@ import pandas as pd
 
 from compiler_admin import FORMATS, Format
 from compiler_admin.services import files
-from compiler_admin.services.google import ORG_UNITS, get_users
+from compiler_admin.services.google import GoogleOrgs, GoogleUsers
 from compiler_admin.services.toggl import GROUPS, TogglUsers
 
 
 def google(format: int = Format.BASIC, inactive: bool = False, account_type: str = "", **kwargs):
     """Use GAM to print the users in the Google Workspace."""
-    if account_type and account_type not in ORG_UNITS:
+    if account_type and account_type not in GoogleOrgs.ORG_UNITS:
         raise ValueError(f"Unexpected account_type: {account_type}")
 
-    org_unit = ORG_UNITS.get(account_type)
+    org_unit = GoogleOrgs.ORG_UNITS.get(account_type)
     org_units = [org_unit] if org_unit else []
-    output = get_users(format=format, inactive=inactive, org_units=org_units, **kwargs)
+    output = GoogleUsers().get(inactive=inactive, format=format, org_units=org_units, **kwargs)
     click.echo(output)
 
 
@@ -61,7 +61,7 @@ def toggl(format: int = Format.BASIC, inactive: bool = False, account_type: str 
         files.write_json(stdout, users)
 
 
-ACCOUNT_TYPES = set((*GROUPS.keys(), *ORG_UNITS.keys()))
+ACCOUNT_TYPES = set((*GROUPS.keys(), *GoogleOrgs.ORG_UNITS.keys()))
 USER_SYSTEMS = {"google": google, "toggl": toggl}
 
 

--- a/compiler_admin/commands/user/backupcodes.py
+++ b/compiler_admin/commands/user/backupcodes.py
@@ -1,18 +1,18 @@
 import click
 
 from compiler_admin import Result
-from compiler_admin.services.google import get_backup_codes, user_account_name, user_exists
+from compiler_admin.services.google import GoogleAccount
 
 
 @click.command()
 @click.argument("username")
 def backupcodes(username: str, **kwargs):
     """Get backup codes for the user, creating a new set if needed."""
-    account = user_account_name(username)
+    account = GoogleAccount(username)
 
-    if not user_exists(account):
+    if not account.exists():
         click.echo(f"User does not exist: {account}")
         raise SystemExit(Result.FAILURE)
 
-    backup_codes = get_backup_codes(account)
+    backup_codes = account.get_backup_codes()
     click.echo(backup_codes)

--- a/compiler_admin/commands/user/convert.py
+++ b/compiler_admin/commands/user/convert.py
@@ -1,62 +1,50 @@
 import click
 
 from compiler_admin import Result
-from compiler_admin.services.google import (
-    GROUP_PARTNERS,
-    GROUP_STAFF,
-    ORG_UNITS,
-    OU_CONTRACTORS,
-    OU_PARTNERS,
-    OU_STAFF,
-    add_user_to_group,
-    move_user_ou,
-    remove_user_from_group,
-    user_account_name,
-    user_exists,
-    user_is_partner,
-    user_is_staff,
-)
+from compiler_admin.services.google import GoogleAccount, GoogleGroups, GoogleOrgs
 
 
 @click.command()
 @click.option("-f", "--force", is_flag=True, help="Don't ask for confirmation.")
 @click.argument("username")
-@click.argument("account_type", type=click.Choice(ORG_UNITS.keys(), case_sensitive=False))
+@click.argument("account_type", type=click.Choice(GoogleOrgs.ORG_UNITS.keys(), case_sensitive=False))
 @click.pass_context
 def convert(ctx: click.Context, username: str, account_type: str, **kwargs):
     """Convert a user of one type to another."""
-    account = user_account_name(username)
+    account = GoogleAccount(username)
+    groups = GoogleGroups()
+    orgs = GoogleOrgs()
 
-    if not user_exists(account):
+    if not account.exists():
         click.echo(f"User does not exist: {account}")
         raise SystemExit(Result.FAILURE)
 
-    ou = ORG_UNITS[account_type]
+    ou = orgs[account_type]
     click.echo(f"User exists, converting to: {ou} for {account}")
 
-    if ou == OU_CONTRACTORS:
-        if user_is_partner(account):
-            remove_user_from_group(account, GROUP_PARTNERS)
-            remove_user_from_group(account, GROUP_STAFF)
-        elif user_is_staff(account):
-            remove_user_from_group(account, GROUP_STAFF)
+    if ou == orgs.OU_CONTRACTORS:
+        if account.is_partner():
+            groups.remove_user(account, groups.GROUP_PARTNERS)
+            groups.remove_user(account, groups.GROUP_STAFF)
+        elif account.is_staff():
+            groups.remove_user(account, groups.GROUP_STAFF)
 
-    elif ou == OU_STAFF:
-        if user_is_partner(account):
-            remove_user_from_group(account, GROUP_PARTNERS)
-        elif user_is_staff(account):
+    elif ou == orgs.OU_STAFF:
+        if account.is_partner():
+            groups.remove_user(account, groups.GROUP_PARTNERS)
+        elif account.is_staff():
             click.echo(f"User is already staff: {account}")
             raise SystemExit(Result.FAILURE)
-        add_user_to_group(account, GROUP_STAFF)
+        groups.add_user(account, groups.GROUP_STAFF)
 
-    elif ou == OU_PARTNERS:
-        if user_is_partner(account):
+    elif ou == orgs.OU_PARTNERS:
+        if account.is_partner():
             click.echo(f"User is already partner: {account}")
             raise SystemExit(Result.FAILURE)
-        if not user_is_staff(account):
-            add_user_to_group(account, GROUP_STAFF)
-        add_user_to_group(account, GROUP_PARTNERS)
+        if not account.is_staff():
+            groups.add_user(account, groups.GROUP_STAFF)
+        groups.add_user(account, groups.GROUP_PARTNERS)
 
-    move_user_ou(account, ou)
+    orgs.move_user(account, ou)
 
     click.echo(f"Account conversion complete for: {account}")

--- a/compiler_admin/commands/user/create.py
+++ b/compiler_admin/commands/user/create.py
@@ -1,14 +1,7 @@
 import click
 
 from compiler_admin import Result
-from compiler_admin.services.google import (
-    GROUP_TEAM,
-    USER_HELLO,
-    CallGAMCommand,
-    add_user_to_group,
-    user_account_name,
-    user_exists,
-)
+from compiler_admin.services.google import GoogleAccount, GoogleGroups, GoogleUsers
 
 
 @click.command(context_settings={"ignore_unknown_options": True})
@@ -24,23 +17,15 @@ def create(username: str, notify: str = "", gam_args: list = []):
 
     <https://github.com/GAM-team/GAM/wiki/Users#create-a-user>
     """
-    account = user_account_name(username)
+    account = GoogleAccount(username)
 
-    if user_exists(account):
+    if account.exists():
         click.echo(f"User already exists: {account}")
         raise SystemExit(Result.FAILURE)
 
     click.echo(f"User does not exist, continuing: {account}")
 
-    command = ("create", "user", account, "password", "random", "changepassword")
-
-    if notify:
-        command += ("notify", notify, "from", USER_HELLO)
-
-    command += (*gam_args,)
-
-    CallGAMCommand(command)
-
-    add_user_to_group(account, GROUP_TEAM)
+    GoogleUsers().create(account, notify, *gam_args)
+    GoogleGroups(GoogleGroups.GROUP_TEAM).add_user(account)
 
     click.echo(f"User created successfully: {account}")

--- a/compiler_admin/commands/user/deactivate.py
+++ b/compiler_admin/commands/user/deactivate.py
@@ -2,14 +2,7 @@ import click
 
 from compiler_admin import Result
 from compiler_admin.commands.user.reset import reset
-from compiler_admin.services.google import (
-    OU_ALUMNI,
-    CallGAMCommand,
-    move_user_ou,
-    user_account_name,
-    user_exists,
-    user_is_deactivated,
-)
+from compiler_admin.services.google import GoogleAccount, GoogleOrgs, GoogleUsers
 
 
 @click.command()
@@ -33,13 +26,15 @@ def deactivate(
     ctx: click.Context, username: str, force: bool = False, recovery_email: str = "", recovery_phone: str = "", **kwargs
 ):
     """Deactivate (but do not delete) a user."""
-    account = user_account_name(username)
+    account = GoogleAccount(username)
+    google_users = GoogleUsers()
+    google_orgs = GoogleOrgs()
 
-    if not user_exists(account):
+    if not account.exists():
         click.echo(f"User does not exist: {account}")
         raise SystemExit(Result.FAILURE)
 
-    if user_is_deactivated(account):
+    if account.is_deactivated():
         click.echo("User is already deactivated")
         raise SystemExit(Result.FAILURE)
 
@@ -51,30 +46,22 @@ def deactivate(
 
     click.echo(f"User exists, deactivating: {account}")
 
-    click.echo("Removing from groups")
-    CallGAMCommand(("user", account, "delete", "groups"))
+    click.echo(f"Moving to OU: {GoogleOrgs.OU_ALUMNI}")
+    google_orgs.move_user(account, GoogleOrgs.OU_ALUMNI)
 
-    click.echo(f"Moving to OU: {OU_ALUMNI}")
-    move_user_ou(account, OU_ALUMNI)
+    click.echo("Removing from groups")
+    google_users.remove_from_groups(account)
 
     # reset password, sign out
     ctx.forward(reset)
 
     click.echo("Clearing user profile info")
-    for prop in ["address", "location", "otheremail", "phone"]:
-        command = ("update", "user", account, prop, "clear")
-        CallGAMCommand(command)
+    google_users.clear_profile(account)
 
-    click.echo("Resetting recovery email")
-    command = ("update", "user", account, "recoveryemail", recovery_email)
-    CallGAMCommand(command)
-
-    click.echo("Resetting recovery phone")
-    command = ("update", "user", account, "recoveryphone", recovery_phone)
-    CallGAMCommand(command)
+    click.echo("Resetting recovery email and phone")
+    google_users.reset_recovery_info(account=account, recovery_email=recovery_email, recovery_phone=recovery_phone)
 
     click.echo("Turning off 2FA")
-    command = ("user", account, "turnoff2sv")
-    CallGAMCommand(command)
+    google_users.disable_2fa(account)
 
     click.echo(f"User is deactivated: {account}")

--- a/compiler_admin/commands/user/delete.py
+++ b/compiler_admin/commands/user/delete.py
@@ -1,7 +1,7 @@
 import click
 
 from compiler_admin import Result
-from compiler_admin.services.google import CallGAMCommand, user_account_name, user_exists
+from compiler_admin.services.google import GoogleAccount, GoogleUsers
 
 
 @click.command()
@@ -9,9 +9,10 @@ from compiler_admin.services.google import CallGAMCommand, user_account_name, us
 @click.argument("username")
 def delete(username: str, force: bool = False, **kwargs):
     """Delete a user account."""
-    account = user_account_name(username)
+    account = GoogleAccount(username)
+    google = GoogleUsers(account)
 
-    if not user_exists(account):
+    if not account.exists():
         click.echo(f"User does not exist: {account}")
         raise SystemExit(Result.FAILURE)
 
@@ -22,5 +23,4 @@ def delete(username: str, force: bool = False, **kwargs):
             return
 
     click.echo(f"User exists, deleting: {account}")
-
-    CallGAMCommand(("delete", "user", account, "noactionifalias"))
+    google.delete(account)

--- a/compiler_admin/commands/user/offboard.py
+++ b/compiler_admin/commands/user/offboard.py
@@ -1,11 +1,9 @@
-from tempfile import NamedTemporaryFile
-
 import click
 
 from compiler_admin import Result
 from compiler_admin.commands.user.deactivate import deactivate
 from compiler_admin.commands.user.delete import delete
-from compiler_admin.services.google import USER_ARCHIVE, CallGAMCommand, CallGYBCommand, user_account_name, user_exists
+from compiler_admin.services.google import GoogleAccount, GoogleArchive, GoogleUsers
 
 
 @click.command()
@@ -20,16 +18,20 @@ def offboard(ctx: click.Context, username: str, alias: str = "", _delete: bool =
 
     Deactivate, back up email, transfer Calendar/Drive, and optionally delete.
     """
-    account = user_account_name(username)
+    account = GoogleAccount(username)
+    google_users = GoogleUsers()
+    google_archive = GoogleArchive()
 
-    if not user_exists(account):
+    if not account.exists():
         click.echo(f"User does not exist: {account}")
         raise SystemExit(Result.FAILURE)
 
-    alias_account = user_account_name(alias)
-    if alias_account and not user_exists(alias_account):
-        click.echo(f"Alias target user does not exist: {alias_account}")
-        raise SystemExit(Result.FAILURE)
+    alias_account = None
+    if alias:
+        alias_account = GoogleAccount(alias)
+        if not alias_account.exists():
+            click.echo(f"Alias target user does not exist: {alias_account}")
+            raise SystemExit(Result.FAILURE)
 
     if not force:
         cont = input(f"Offboard account {account} {' (assigning alias to ' + alias_account + ')' if alias else ''}? (Y/n): ")
@@ -43,22 +45,16 @@ def offboard(ctx: click.Context, username: str, alias: str = "", _delete: bool =
     ctx.forward(deactivate)
 
     click.echo("Backing up email")
-    CallGYBCommand(("--service-account", "--email", account, "--action", "backup"))
+    google_archive.create_email_backup(account)
 
     click.echo("Starting Drive and Calendar transfer")
-    CallGAMCommand(("create", "transfer", account, "calendar,drive", USER_ARCHIVE, "all", "releaseresources"))
+    google_archive.archive_content(account)
 
-    status = ""
-    with NamedTemporaryFile("w+") as stdout:
-        while "Overall Transfer Status: completed" not in status:
-            click.echo("Transfer in progress")
-            CallGAMCommand(("show", "transfers", "olduser", username), stdout=stdout.name, stderr="stdout")
-            status = " ".join(stdout.readlines())
-            stdout.seek(0)
-        click.echo("Transfer complete")
+    google_archive.await_archive_completion(account, lambda: click.echo("Transfer in progress"))
+    click.echo("Transfer complete")
 
     click.echo("Deprovisioning POP/IMAP")
-    CallGAMCommand(("user", account, "deprovision", "popimap"))
+    google_users.deprovision_popimap(account)
 
     # call the delete command
     if _delete:
@@ -66,6 +62,6 @@ def offboard(ctx: click.Context, username: str, alias: str = "", _delete: bool =
 
     if alias_account:
         click.echo(f"Adding an alias to account: {alias_account}")
-        CallGAMCommand(("create", "alias", account, "user", alias_account))
+        alias_account.add_email_alias(account)
 
     click.echo(f"Offboarding for user complete: {account}")

--- a/compiler_admin/commands/user/reactivate.py
+++ b/compiler_admin/commands/user/reactivate.py
@@ -3,18 +3,7 @@ import click
 from compiler_admin import Result
 from compiler_admin.commands.user.backupcodes import backupcodes
 from compiler_admin.commands.user.reset import reset
-from compiler_admin.services.google import (
-    GROUP_STAFF,
-    GROUP_TEAM,
-    OU_CONTRACTORS,
-    OU_STAFF,
-    CallGAMCommand,
-    add_user_to_group,
-    move_user_ou,
-    user_account_name,
-    user_exists,
-    user_is_deactivated,
-)
+from compiler_admin.services.google import GoogleAccount, GoogleGroups, GoogleOrgs, GoogleUsers
 
 
 @click.command()
@@ -45,13 +34,13 @@ def reactivate(
     **kwargs,
 ):
     """Reactivate a previously deactivated user."""
-    account = user_account_name(username)
+    account = GoogleAccount(username)
 
-    if not user_exists(account):
+    if not account.exists():
         click.echo(f"User does not exist: {account}")
         raise SystemExit(Result.FAILURE)
 
-    if not user_is_deactivated(account):
+    if not account.is_deactivated():
         click.echo("User is not deactivated, cannot reactivate")
         raise SystemExit(Result.FAILURE)
 
@@ -63,27 +52,23 @@ def reactivate(
 
     click.echo(f"User exists, reactivating: {account}")
 
-    click.echo(f"Adding to group: {GROUP_TEAM}")
-    add_user_to_group(account, GROUP_TEAM)
+    click.echo(f"Adding to group: {GoogleGroups.GROUP_TEAM}")
+    GoogleGroups(GoogleGroups.GROUP_TEAM).add_user(account)
 
     if staff:
-        click.echo(f"Moving to OU: {OU_STAFF}")
-        move_user_ou(account, OU_STAFF)
-        click.echo(f"Adding to group: {GROUP_STAFF}")
-        add_user_to_group(account, GROUP_STAFF)
+        click.echo(f"Moving to OU: {GoogleOrgs.OU_STAFF}")
+        GoogleOrgs(GoogleOrgs.OU_STAFF).move_user(account)
+        click.echo(f"Adding to group: {GoogleGroups.GROUP_STAFF}")
+        GoogleGroups(GoogleGroups.GROUP_STAFF).add_user(account)
     else:
-        click.echo(f"Moving to OU: {OU_CONTRACTORS}")
-        move_user_ou(account, OU_CONTRACTORS)
+        click.echo(f"Moving to OU: {GoogleOrgs.OU_CONTRACTORS}")
+        GoogleOrgs(GoogleOrgs.OU_CONTRACTORS).move_user(account)
 
     # reset password, sign out
     ctx.forward(reset)
 
     click.echo("Update user profile info")
-    profile = dict(recoveryemail=recovery_email, recoveryphone=recovery_phone)
-    profile = {k: v for k, v in profile.items() if v}
-    for prop, val in profile.items():
-        command = ("update", "user", account, prop, val)
-        CallGAMCommand(command)
+    GoogleUsers().reset_recovery_info(account=account, recovery_email=recovery_email, recovery_phone=recovery_phone)
 
     # get the user's backup codes
     ctx.forward(backupcodes)

--- a/compiler_admin/commands/user/reset.py
+++ b/compiler_admin/commands/user/reset.py
@@ -2,7 +2,7 @@ import click
 
 from compiler_admin import Result
 from compiler_admin.commands.user.signout import signout
-from compiler_admin.services.google import USER_HELLO, CallGAMCommand, user_account_name, user_exists
+from compiler_admin.services.google import GoogleAccount, GoogleUsers
 
 
 @click.command()
@@ -12,9 +12,10 @@ from compiler_admin.services.google import USER_HELLO, CallGAMCommand, user_acco
 @click.pass_context
 def reset(ctx: click.Context, username: str, force: bool = False, notify: str = "", **kwargs):
     """Reset a user's password."""
-    account = user_account_name(username)
+    account = GoogleAccount(username)
+    google = GoogleUsers()
 
-    if not user_exists(account):
+    if not account.exists():
         click.echo(f"User does not exist: {account}")
         raise SystemExit(Result.FAILURE)
 
@@ -26,11 +27,7 @@ def reset(ctx: click.Context, username: str, force: bool = False, notify: str = 
 
     click.echo(f"User exists, resetting password: {account}")
 
-    command = ("update", "user", account, "password", "random", "changepassword")
-    if notify:
-        command += ("notify", notify, "from", USER_HELLO)
-
-    CallGAMCommand(command)
+    google.reset_password(account=account, notify=notify)
 
     # call the signout command
     ctx.forward(signout)

--- a/compiler_admin/commands/user/restore.py
+++ b/compiler_admin/commands/user/restore.py
@@ -3,34 +3,22 @@ import pathlib
 import click
 
 from compiler_admin import Result
-from compiler_admin.services.google import USER_ARCHIVE, CallGYBCommand, user_account_name
+from compiler_admin.services.google import GoogleAccount, GoogleArchive, GoogleUsers
 
 
 @click.command()
 @click.argument("username")
 def restore(username: str):
     """Restore an email backup from a prior offboarding."""
-    account = user_account_name(username)
+    account = GoogleAccount(username)
     backup_dir = f"GYB-GMail-Backup-{account}"
 
     if not pathlib.Path(backup_dir).exists():
         click.echo(f"Couldn't find a local backup: {backup_dir}")
         raise SystemExit(Result.FAILURE)
 
-    click.echo(f"Found backup, starting restore process with dest: {USER_ARCHIVE} for account: {account}")
+    click.echo(f"Found backup, starting restore process with dest: {GoogleUsers.USER_ARCHIVE} for account: {account}")
 
-    CallGYBCommand(
-        (
-            "--service-account",
-            "--email",
-            USER_ARCHIVE,
-            "--action",
-            "restore",
-            "--local-folder",
-            backup_dir,
-            "--label-restored",
-            account,
-        )
-    )
+    GoogleArchive().restore_email_backup(account=account, backup_dir=backup_dir)
 
     click.echo(f"Email restore complete for: {account}")

--- a/compiler_admin/commands/user/signout.py
+++ b/compiler_admin/commands/user/signout.py
@@ -1,7 +1,7 @@
 import click
 
 from compiler_admin import Result
-from compiler_admin.services.google import CallGAMCommand, user_account_name, user_exists
+from compiler_admin.services.google import GoogleAccount, GoogleUsers
 
 
 @click.command()
@@ -9,9 +9,10 @@ from compiler_admin.services.google import CallGAMCommand, user_account_name, us
 @click.argument("username")
 def signout(username: str, force: bool = False, **kwargs):
     """Sign a user out from all active sessions."""
-    account = user_account_name(username)
+    account = GoogleAccount(username)
+    google = GoogleUsers()
 
-    if not user_exists(account):
+    if not account.exists():
         click.echo(f"User does not exist: {account}")
         raise SystemExit(Result.FAILURE)
 
@@ -23,4 +24,4 @@ def signout(username: str, force: bool = False, **kwargs):
 
     click.echo(f"User exists, signing out from all active sessions: {account}")
 
-    CallGAMCommand(("user", account, "signout"))
+    google.signout(account)

--- a/compiler_admin/services/google.py
+++ b/compiler_admin/services/google.py
@@ -4,130 +4,272 @@ import json
 import subprocess
 import sys
 from tempfile import NamedTemporaryFile
-from typing import IO, Any, Sequence
+from typing import IO, Any, Callable, Sequence
 
-# import and alias CallGAMCommand so we can simplify usage in this app
-from gam import CallGAMCommand as __CallGAMCommand, initializeLogging
+from gam import CallGAMCommand, initializeLogging
 
 from compiler_admin import Format, Result
 
 initializeLogging()
 
-GAM = "gam"
-GYB = "gyb"
 
-# Primary domain
-DOMAIN = "compiler.la"
+class GoogleService:
+    GAM = "gam"
+    GYB = "gyb"
 
-# Org structure
-OU_ALUMNI = "/alumni"
-OU_CONTRACTORS = "/contractors"
-OU_SERVICE_ACCOUNTS = "/service-accounts"
-OU_STAFF = "/staff"
-OU_PARTNERS = f"{OU_STAFF}/partners"
+    def gam_command(self, args: Sequence[str], stdout: str = None, stderr: str = None) -> int:
+        """Call GAM with the provided arguments, optionally redirecting stdout and/or stderr."""
+        if stdout:
+            args = ("redirect", "stdout", stdout, *args)
 
-ORG_UNITS = dict(
-    alumni=OU_ALUMNI, contractors=OU_CONTRACTORS, service_accounts=OU_SERVICE_ACCOUNTS, staff=OU_STAFF, partners=OU_PARTNERS
-)
+        if stderr:
+            args = ("redirect", "stderr", stderr, *args)
 
+        if not args[0] == self.GAM:
+            args = (self.GAM, *args)
 
-def user_account_name(username: str) -> str:
-    """Return the full user account in the Compiler domain.
+        # convert all args to str to ensure proper GAM calling
+        args = tuple(str(a) for a in args)
 
-    Args:
-        username (str): The username sans domain of a Compiler account.
-    Returns:
-        username@compiler.la
-    """
-    if username is None:
-        return None
-    if username.endswith(f"@{DOMAIN}"):
-        return username
-    return f"{username}@{DOMAIN}"
+        return int(CallGAMCommand(args))
 
-
-# Archive account
-USER_ARCHIVE = user_account_name("archive")
-
-# Hello account
-USER_HELLO = user_account_name("hello")
-
-# Groups
-GROUP_PARTNERS = user_account_name("partners")
-GROUP_STAFF = user_account_name("staff")
-GROUP_TEAM = user_account_name("team")
-
-
-def CallGAMCommand(args: Sequence[str], stdout: str = None, stderr: str = None) -> int:
-    """Call GAM with the provided arguments, optionally redirecting stdout and/or stderr."""
-    if stdout:
-        args = ("redirect", "stdout", stdout, *args)
-
-    if stderr:
-        args = ("redirect", "stderr", stderr, *args)
-
-    if not args[0] == GAM:
-        args = (GAM, *args)
-
-    return int(__CallGAMCommand(args))
-
-
-def CallGYBCommand(args: Sequence[str], stdout: IO[Any] = sys.stdout, stderr: IO[Any] = sys.stderr) -> int:
-    """Call GYB with the provided arguments."""
-    if not args[0] == GYB:
-        args = (GYB, *args)
-
-    return subprocess.call(args, stdout=stdout, stderr=stderr)
-
-
-def add_user_to_group(username: str, group: str) -> int:
-    """Add a user to a group."""
-    return CallGAMCommand(("user", username, "add", "groups", "member", group))
-
-
-def get_backup_codes(username: str) -> str:
-    if not user_exists(username):
-        print(f"User does not exist: {username}")
-        return ""
-
-    output = ""
-    command = ("user", username, "show", "backupcodes")
-    with NamedTemporaryFile("w+") as stdout:
-        CallGAMCommand(command, stdout=stdout.name, stderr="stdout")
-        output = "".join(stdout.readlines())
-
-    if "Show 0 Backup Verification Codes" in output:
-        command = ("user", username, "update", "backupcodes")
+    def gam_command_output(self, args: Sequence[str], stderr: str = "stderr") -> list[str]:
+        """Call GAM with the provided arguments, optionally redirecting stderr. Returns stdout lines as a list of str."""
         with NamedTemporaryFile("w+") as stdout:
-            CallGAMCommand(command, stdout=stdout.name, stderr="stdout")
-            output = "".join(stdout.readlines())
+            self.gam_command(args, stdout=stdout.name, stderr=stderr)
+            return stdout.readlines()
 
-    return output
+    def gyb_command(self, args: Sequence[str], stdout: IO[Any] = sys.stdout, stderr: IO[Any] = sys.stderr) -> int:
+        """Call GYB with the provided arguments."""
+        if not args[0] == self.GYB:
+            args = (self.GYB, *args)
+
+        # convert all args to str to ensure proper GYB calling
+        args = tuple(str(a) for a in args)
+
+        return subprocess.call(args, stdout=stdout, stderr=stderr)
 
 
-def get_groups(format: int = Format.BASIC, **kwargs) -> int:
-    """Get information about the groups."""
-    output = ""
-    command = ("print", "groups")
+class GoogleAccount(GoogleService):
+    """Models a user account in the Compiler domain."""
 
-    if len(kwargs) > 0:
-        for k, v in kwargs.items():
-            command += (k, v)
+    DOMAIN = "compiler.la"
 
-    if format in [Format.CSV, Format.JSON]:
-        command += ("allfields",)
-    if format == Format.JSON:
-        command += (
-            "members",
-            "managers",
-            "owners",
-            "formatjson",
+    def __init__(self, username: str):
+        self.username = username or ""
+        if self.username:
+            self.account = username if username.endswith(f"@{self.DOMAIN}") else f"{username}@{self.DOMAIN}"
+        else:
+            self.account = ""
+
+    def __eq__(self, value):
+        return str(self) == value
+
+    def __str__(self):
+        return self.account
+
+    def add_email_alias(self, alias: str) -> int:
+        """Add a new email alias for this account.
+
+        Args:
+            alias (str): The user@compiler.la to add as an email alias for this account.
+
+        Returns:
+            int: A code indicating if the operation succeeded or failed.
+        """
+        command = ("create", "alias", alias, "user", self)
+        self.gam_command(command)
+
+    def exists(self) -> bool:
+        """Checks if an account exists.
+
+        Returns:
+            True if the account exists. False otherwise.
+        """
+        return self.get_info() != {}
+
+    def get_backup_codes(self) -> str:
+        """Gets an account's backup codes, refreshing if needed.
+
+        Returns:
+            (str): The backup code output.
+        """
+        if not self.exists():
+            print(f"User does not exist: {self}")
+            return ""
+
+        command = ("user", self, "show", "backupcodes")
+        output = "".join(self.gam_command_output(command))
+
+        if "Show 0 Backup Verification Codes" in output:
+            command = ("user", self, "update", "backupcodes")
+            output = "".join(self.gam_command_output(command))
+
+        return output
+
+    def get_info(self) -> dict:
+        """Get a dict of basic user information.
+
+        Args:
+            account (GoogleAccount): The user@compiler.la to check for existence.
+
+        Returns:
+            (dict): The user's information.
+        """
+        with NamedTemporaryFile("w+") as stdout:
+            res = self.gam_command(("info", "user", str(self), "quick"), stdout=stdout.name)
+            if res != Result.SUCCESS:
+                # user doesn't exist
+                return {}
+            # user exists, read data
+            lines = stdout.readlines()
+            # split on newline and filter out lines that aren't line "Key:Value" and empty value lines like "Key:<empty>"
+            lines = [L.strip() for L in lines if len(L.split(":")) == 2 and L.split(":")[1].strip()]
+            # make a map by splitting the lines, trimming key and value
+            info = {}
+            for line in lines:
+                k, v = line.split(":")
+                info[k.strip()] = v.strip()
+            return info
+
+    def is_deactivated(self) -> bool:
+        """Checks if the account is deactivated.
+
+        Returns:
+            True if the user is deactivated. False otherwise.
+        """
+        return GoogleOrgs(GoogleOrgs.OU_ALUMNI).contains_user(self)
+
+    def is_partner(self) -> bool:
+        """Checks if the account is a Compiler Partner.
+
+        Returns:
+            True if the user is a Partner. False otherwise.
+        """
+        return GoogleGroups(GoogleGroups.GROUP_PARTNERS).contains_user(self)
+
+    def is_staff(self) -> bool:
+        """Checks if an account is a Compiler Staff.
+
+        Returns:
+            True if the user is a Staff. False otherwise.
+        """
+        return GoogleGroups(GoogleGroups.GROUP_STAFF).contains_user(self)
+
+
+class GoogleArchive(GoogleService):
+    def archive_content(self, account: GoogleAccount) -> int:
+        """DESTRUCTIVE! Archive this account's Calendar and Drive content.
+
+        Args:
+            account (GoogleAccount): The account with content to archive.
+
+        Returns:
+            int: A code indicating if the operation succeeded or failed.
+        """
+        command = ("create", "transfer", account, "calendar,drive", GoogleUsers.USER_ARCHIVE, "all", "releaseresources")
+        return self.gam_command(command)
+
+    def await_archive_completion(self, account: GoogleAccount, callback: Callable[[str, str], None] = None) -> int:
+        status = ""
+        command = ("show", "transfers", "olduser", account)
+
+        while "Overall Transfer Status: completed" not in status:
+            pre_status = status
+            status = " ".join(self.gam_command_output(command, stderr="stdout"))
+            if callback:
+                callback(pre_status, status)
+
+    def create_email_backup(self, account: GoogleAccount) -> int:
+        """Create a backup of the account's email.
+
+        Args:
+            account (GoogleAccount): The account to create an email backup.
+
+        Returns:
+            int: A code indicating if the operation succeeded or failed.
+        """
+        command = ("--service-account", "--email", account, "--action", "backup")
+        return self.gyb_command(command)
+
+    def restore_email_backup(self, account: GoogleAccount, backup_dir: str) -> int:
+        """Restore a backup of the account's email.
+
+        Args:
+            account (GoogleAccount): The account to create an email backup.
+            backup_dir (str): The path to a directory containing the account's email backup.
+
+        Returns:
+            int: A code indicating if the operation succeeded or failed.
+        """
+        command = (
+            "--service-account",
+            "--email",
+            GoogleUsers.USER_ARCHIVE,
+            "--action",
+            "restore",
+            "--local-folder",
+            backup_dir,
+            "--label-restored",
+            account,
         )
+        return self.gyb_command(command)
 
-    with NamedTemporaryFile("w+") as stdout:
-        CallGAMCommand(command, stdout=stdout.name)
-        lines = stdout.readlines()
 
+class GoogleGroups(GoogleService):
+
+    GROUP_PARTNERS = GoogleAccount("partners")
+    GROUP_STAFF = GoogleAccount("staff")
+    GROUP_TEAM = GoogleAccount("team")
+
+    def __init__(self, group: GoogleAccount = None):
+        self._group = group
+
+    def add_user(self, account: GoogleAccount, group: GoogleAccount = None):
+        """Add a user to a group.
+
+        Args:
+            account (GoogleAccount): The user@compiler.la to add.
+            group (GoogleAccount): The group@compiler.la to add the account to.
+        """
+        group = group or self._group
+        return self.gam_command(("user", account, "add", "groups", "member", group))
+
+    def contains_user(self, account: GoogleAccount, group: GoogleAccount = None) -> bool:
+        """Checks if the account is in a group.
+
+        Args:
+            account (GoogleAccount): The user@compiler.la to check for group membership.
+            group (GoogleAccount): The group@compiler.la to check for account's membership.
+
+        Returns:
+            True if the user is a member of the group. False otherwise.
+        """
+        group = group or self._group
+        command = ("print", "groups", "member", account)
+        output = "".join(self.gam_command_output(command))
+        return str(group) in output
+
+    def get(self, format: int = Format.BASIC, **kwargs) -> int:
+        """Get information about the groups."""
+        output = ""
+        command = ("print", "groups")
+
+        if len(kwargs) > 0:
+            for k, v in kwargs.items():
+                command += (k, v)
+
+        if format in [Format.CSV, Format.JSON]:
+            command += ("allfields",)
+        if format == Format.JSON:
+            command += (
+                "members",
+                "managers",
+                "owners",
+                "formatjson",
+            )
+
+        lines = self.gam_command_output(command)
         if format == Format.JSON:
             # GAM returns a CSV structure like "email,JSON,JSON-settings"
             # extract JSON cols to array of dicts for convenience
@@ -160,197 +302,246 @@ def get_groups(format: int = Format.BASIC, **kwargs) -> int:
         else:
             output = "".join(lines)
 
-    return output
+        return output
+
+    def remove_user(self, account: GoogleAccount, group: GoogleAccount = None):
+        """Remove a user from a group."""
+        group = group or self._group
+        return self.gam_command(("update", "group", group, "delete", account))
 
 
-def get_org_units(**kwargs) -> str:
-    """Print information about the org units."""
-    output = ""
-    command = ("print", "orgs")
+class GoogleOrgs(GoogleService):
+    OU_ALUMNI = "/alumni"
+    OU_CONTRACTORS = "/contractors"
+    OU_SERVICE_ACCOUNTS = "/service-accounts"
+    OU_STAFF = "/staff"
+    OU_PARTNERS = f"{OU_STAFF}/partners"
 
-    if len(kwargs) > 0:
-        for k, v in kwargs.items():
-            command += (k, v)
+    ORG_UNITS = dict(
+        alumni=OU_ALUMNI,
+        contractors=OU_CONTRACTORS,
+        service_accounts=OU_SERVICE_ACCOUNTS,
+        staff=OU_STAFF,
+        partners=OU_PARTNERS,
+    )
 
-    with NamedTemporaryFile("w+") as stdout:
-        CallGAMCommand(command, stdout=stdout.name, stderr="stdout")
-        lines = stdout.readlines()
-        output = "".join(lines)
+    def __init__(self, ou: str = None):
+        self._ou = ou
 
-    return output
+    def __getitem__(self, key):
+        return self.ORG_UNITS.get(key)
+
+    def contains_user(self, account: GoogleAccount, ou: str = None) -> bool:
+        """Checks if the account is in an OU.
+
+        Args:
+            account (GoogleAccount): The user@compiler.la to check for membership.
+            ou (str): The name of an OU to check for account's membership.
+
+        Returns:
+            True if the account is a member of the OU. False otherwise.
+        """
+        ou = ou or self._ou
+
+        if ou not in self.ORG_UNITS.values():
+            raise ValueError(f"Unexpected OU: {ou}")
+
+        command = ("info", "ou", ou)
+        output = "".join(self.gam_command_output(command))
+        return str(account) in output
+
+    def get(self, **kwargs) -> str:
+        """Print information about the org units."""
+        command = ("print", "orgs")
+
+        if len(kwargs) > 0:
+            for k, v in kwargs.items():
+                command += (k, v)
+
+        return "".join(self.gam_command_output(command))
+
+    def move_user(self, account: GoogleAccount, ou: str = None) -> int:
+        """Move an account into a new OU."""
+        ou = ou or self._ou
+
+        if ou not in self.ORG_UNITS.values():
+            raise ValueError(f"Unexpected OU: {ou}")
+
+        return self.gam_command(("update", "ou", ou, "move", account))
 
 
-def get_users(format: int = Format.BASIC, inactive: bool = False, org_units: list[str] = [], **kwargs) -> str:
-    flag = str(inactive).lower()
-    output = ""
-    queries = ""
-    command = ("print", "users", "issuspended", flag, "isarchived", flag)
+class GoogleUsers(GoogleService):
+    """Interact with users in the Compiler domain."""
 
-    if len(kwargs) > 0:
-        for k, v in kwargs.items():
-            command += (k, v)
+    # Archive account
+    USER_ARCHIVE = GoogleAccount("archive")
+    # Hello account
+    USER_HELLO = GoogleAccount("hello")
 
-    if len(org_units) > 0:
-        workspace_org_units = ORG_UNITS.values()
-        if not all((ou in workspace_org_units for ou in org_units)):
-            raise ValueError(f"Unexpected org_unit(s): {', '.join(org_units)}")
-        queries = ",".join([f"'orgUnitPath={ou}'" for ou in org_units])
-        command += ("queries", queries)
+    def clear_profile(self, account: GoogleAccount) -> int:
+        """DESTRUCTIVE! Clears user account profile info.
 
-    if format == Format.CSV:
-        command += ("full",)
-    elif format == Format.JSON:
-        queries = ",".join(org_units)
-        if queries:
-            user_entity = ("ous_arch" if inactive else "ou_na_ns", queries)
-        else:
-            user_entity = ("all", "users_arch_or_susp" if inactive else "users_na_ns")
+        Args:
+            account (GoogleAccount): The user@compiler.la whose profile to clear.
 
-        command = (
-            "info",
-            "users",
-            *user_entity,
-            "nobuildingnames",
-            "noschemas",
-            "formatjson",
-        )
+        Returns:
+            int: A code indicating if the operation succeeded or failed.
+        """
+        for prop in ["address", "location", "otheremail", "phone"]:
+            command = ("update", "user", account, prop, "clear")
+            self.gam_command(command)
 
-    with NamedTemporaryFile("w+") as stdout:
-        CallGAMCommand(command, stdout=stdout.name, stderr="stdout")
-        lines = stdout.readlines()
+    def create(self, account: GoogleAccount, notify: str = None, *args):
+        command = ("create", "user", account, "password", "random", "changepassword")
+        if notify:
+            command += ("notify", notify, "from", self.USER_HELLO)
+        command += (*args,)
+
+        return self.gam_command(command)
+
+    def delete(self, account: GoogleAccount) -> int:
+        """DESTRUCTIVE! Deletes an account.
+
+        Args:
+            account (GoogleAccount): The user@compiler.la to delete.
+
+        Returns:
+            int: A code indicating if the operation succeeded or failed.
+        """
+        command = ("delete", "user", account, "noactionifalias")
+        return self.gam_command(command)
+
+    def deprovision_popimap(self, account: GoogleAccount) -> int:
+        """DESTRUCTIVE! Deprovisions POP/IMAP (email services) for the account.
+
+        Args:
+            account (GoogleAccount): The user@compiler.la to deprovision POP/IMAP for.
+
+        Returns:
+            int: A code indicating if the operation succeeded or failed.
+        """
+        command = ("user", account, "deprovision", "popimap")
+        return self.gam_command(command)
+
+    def disable_2fa(self, account: GoogleAccount) -> int:
+        """DESTRUCTIVE! Disables 2FA on the account.
+
+        Args:
+            account (GoogleAccount): The user@compiler.la to disable 2FA for.
+
+        Returns:
+            int: A code indicating if the operation succeeded or failed.
+        """
+        command = ("user", account, "turnoff2sv")
+        return self.gam_command(command)
+
+    def get(self, format: int = Format.BASIC, inactive: bool = False, org_units: list[str] = [], **kwargs) -> str:
+        """Get a list of accounts in the workspace.
+
+        Args:
+            format (int): The format for the output. Use the `compiler_admin.Format` helper class.
+            inactive (bool): True to display inactive users. False to display active users.
+            org_units (list[str]): A list of org units that, if provided, filters users to only those in any of the org units.
+
+        Returns:
+            str: A formatted list of user accounts.
+        """
+        flag = str(inactive).lower()
+        output = ""
+        queries = ""
+        command = ("print", "users", "issuspended", flag, "isarchived", flag)
+
+        if len(kwargs) > 0:
+            for k, v in kwargs.items():
+                command += (k, v)
+
+        if len(org_units) > 0:
+            workspace_org_units = GoogleOrgs.ORG_UNITS.values()
+            if not all((ou in workspace_org_units for ou in org_units)):
+                raise ValueError(f"Unexpected org_unit(s): {', '.join(org_units)}")
+            queries = ",".join([f"'orgUnitPath={ou}'" for ou in org_units])
+            command += ("queries", queries)
+
+        if format == Format.CSV:
+            command += ("full",)
+        elif format == Format.JSON:
+            queries = ",".join(org_units)
+            if queries:
+                user_entity = ("ous_arch" if inactive else "ou_na_ns", queries)
+            else:
+                user_entity = ("all", "users_arch_or_susp" if inactive else "users_na_ns")
+
+            command = (
+                "info",
+                "users",
+                *user_entity,
+                "nobuildingnames",
+                "noschemas",
+                "formatjson",
+            )
+
+        lines = self.gam_command_output(command)
         if format == Format.JSON:
             # GAM returns JSON record lines, write a JSON array for convenience
             output = f"[{",".join(lines)}]"
         else:
             output = "".join(lines)
 
-    return output
+        return output
 
+    def reset_recovery_info(self, account: GoogleAccount, recovery_email: str, recovery_phone: str) -> int:
+        """DESTRUCTIVE! Resets the account's recovery information.
 
-def move_user_ou(username: str, ou: str) -> int:
-    """Move a user into a new OU."""
-    return CallGAMCommand(("update", "ou", ou, "move", username))
+        Args:
+            account (GoogleAccount): The user@compiler.la to reset recovery info for.
 
+        Returns:
+            int: A code indicating if the operation succeeded or failed.
+        """
+        command = ("update", "user", account, "recoveryemail", recovery_email)
+        res = self.gam_command(command)
 
-def remove_user_from_group(username: str, group: str) -> int:
-    """Remove a user from a group."""
-    return CallGAMCommand(("update", "group", group, "delete", username))
+        command = ("update", "user", account, "recoveryphone", recovery_phone)
+        res += self.gam_command(command)
 
+        return res
 
-def user_exists(username: str) -> bool:
-    """Checks if a user exists.
+    def reset_password(self, account: GoogleAccount, notify: str = None) -> int:
+        """DESTRUCTIVE! Resets the account's password to a new, random password.
 
-    Args:
-        username (str): The user@compiler.la to check for existence.
-    Returns:
-        True if the user exists. False otherwise.
-    """
-    if not str(username).endswith(DOMAIN):
-        print(f"User not in domain: {username}")
-        return False
+        Args:
+            account (GoogleAccount): The user@compiler.la to reset the password for.
+            notify (str): Optional email address to send a notification with the new password.
 
-    info = user_info(username)
+        Returns:
+            int: A code indicating if the operation succeeded or failed.
+        """
+        command = ("update", "user", account, "password", "random", "changepassword")
+        if notify:
+            command += ("notify", notify, "from", GoogleUsers.USER_HELLO)
 
-    return info != {}
+        self.gam_command(command)
 
+    def remove_from_groups(self, account: GoogleAccount) -> int:
+        """DESTRUCTIVE! Removes the account from all groups.
 
-def user_info(username: str) -> dict:
-    """Get a dict of basic user information.
+        Args:
+            account (GoogleAccount): The user@compiler.la to remove from all its groups.
 
-    Args:
-        username (str): The user@compiler.la to get.
-    Returns:
-        A dict of user information
-    """
-    if not str(username).endswith(DOMAIN):
-        print(f"User not in domain: {username}")
-        return {}
+        Returns:
+            int: A code indicating if the operation succeeded or failed.
+        """
+        command = ("user", account, "delete", "groups")
+        return self.gam_command(command)
 
-    with NamedTemporaryFile("w+") as stdout:
-        res = CallGAMCommand(("info", "user", username, "quick"), stdout=stdout.name)
-        if res != Result.SUCCESS:
-            # user doesn't exist
-            return {}
-        # user exists, read data
-        lines = stdout.readlines()
-        # split on newline and filter out lines that aren't line "Key:Value" and empty value lines like "Key:<empty>"
-        lines = [L.strip() for L in lines if len(L.split(":")) == 2 and L.split(":")[1].strip()]
-        # make a map by splitting the lines, trimming key and value
-        info = {}
-        for line in lines:
-            k, v = line.split(":")
-            info[k.strip()] = v.strip()
-        return info
+    def signout(self, account: GoogleAccount) -> int:
+        """Sign a user out from all active sessions.
 
+        Args:
+            account (GoogleAccount): The user@compiler.la to sign out.
 
-def user_in_group(username: str, group: str) -> bool:
-    """Checks if a user is in a group.
-
-    Args:
-        username (str): The user@compiler.la to check for membership in the group.
-        group (str): The group@compiler.la to check for username's membership.
-    Returns:
-        True if the user is a member of the group. False otherwise.
-    """
-    if user_exists(username):
-        with NamedTemporaryFile("w+") as stdout:
-            CallGAMCommand(("print", "groups", "member", username), stdout=stdout.name, stderr="stdout")
-            output = "\n".join(stdout.readlines())
-
-        return group in output
-    else:
-        print(f"User does not exist: {username}")
-        return False
-
-
-def user_in_ou(username: str, ou: str) -> bool:
-    """Checks if a user is in an OU.
-
-    Args:
-        username (str): The user@compiler.la to check for membership in the group.
-        ou (str): The name of an OU to check for username's membership.
-    Returns:
-        True if the user is a member of the OU. False otherwise.
-    """
-    if user_exists(username):
-        with NamedTemporaryFile("w+") as stdout:
-            CallGAMCommand(("info", "ou", ou), stdout=stdout.name, stderr="stdout")
-            output = "\n".join(stdout.readlines())
-        return username in output
-    else:
-        print(f"User does not exist: {username}")
-        return False
-
-
-def user_is_deactivated(username: str) -> bool:
-    """Checks if a user is in an OU.
-
-    Args:
-        username (str): The user@compiler.la to check for membership in the group.
-        ou (str): The name of an OU to check for username's membership.
-    Returns:
-        True if the user is a member of the OU. False otherwise.
-    """
-    return user_in_ou(username, OU_ALUMNI)
-
-
-def user_is_partner(username: str) -> bool:
-    """Checks if a user is a Compiler Partner.
-
-    Args:
-        username (str): The user@compiler.la to check for partner status.
-    Returns:
-        True if the user is a Partner. False otherwise.
-    """
-    return user_in_group(username, GROUP_PARTNERS)
-
-
-def user_is_staff(username: str) -> bool:
-    """Checks if a user is a Compiler Staff.
-
-    Args:
-        username (str): The user@compiler.la to check for staff status.
-    Returns:
-        True if the user is a Staff. False otherwise.
-    """
-    return user_in_group(username, GROUP_STAFF)
+        Returns:
+            int: A code indicating if the operation succeeded or failed.
+        """
+        command = ("user", account, "signout")
+        return self.gam_command(command)

--- a/compiler_admin/services/toggl.py
+++ b/compiler_admin/services/toggl.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 import compiler_admin.services.files as files
 from compiler_admin.api.toggl import TogglOrganization, TogglReports, TogglWorkspace
-from compiler_admin.services.google import user_info as google_user_info
+from compiler_admin.services.google import GoogleAccount
 from compiler_admin.services.time import TimeSummary
 
 GROUPS = dict(contractors="Contractors", service_accounts="Service Accounts", staff="Staff", partners="Partners")
@@ -54,7 +54,7 @@ class TogglTime(TogglService):
         user = info.get(email)
         name = user.get(name_key) if user else None
         if name is None:
-            user = google_user_info(email)
+            user = GoogleAccount(email).get_info()
             name = user.get(name_key) if user else None
             if email in info:
                 info[email].update(user)

--- a/notebooks/toggl-to-harvest.ipynb
+++ b/notebooks/toggl-to-harvest.ipynb
@@ -6,7 +6,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "from compiler_admin.services.google import user_info as google_user_info\n",
+        "from compiler_admin.services.google import GoogleAccount\n",
         "import json\n",
         "import os\n",
         "from pathlib import Path\n",
@@ -165,7 +165,7 @@
         "    user = USER_INFO.get(email)\n",
         "    last_name = user.get(\"Last Name\") if user else None\n",
         "    if last_name is None:\n",
-        "        user = google_user_info(email)\n",
+        "        user = GoogleAccount(email).get_info()\n",
         "        last_name = user.get(\"Last Name\") if user else None\n",
         "        if email in USER_INFO:\n",
         "            USER_INFO[email].update(user)\n",

--- a/tests/commands/ls/test_groups.py
+++ b/tests/commands/ls/test_groups.py
@@ -22,13 +22,8 @@ MOCK_GROUPS = [
 
 
 @pytest.fixture
-def mock_google_get_org_units(mocker):
-    return mocker.patch(f"{MODULE}.get_org_units")
-
-
-@pytest.fixture
-def mock_google_get_groups(mocker):
-    return mocker.patch(f"{MODULE}.get_groups")
+def mock_GoogleGroups(mocker):
+    return mocker.patch(f"{MODULE}.GoogleGroups").return_value
 
 
 @pytest.fixture
@@ -79,17 +74,17 @@ def test_groups__system_unknown(cli_runner, mock_google, mock_toggl):
     mock_toggl.assert_not_called()
 
 
-def test_google(mock_google_get_groups):
+def test_google(mock_GoogleGroups):
     google()
 
-    mock_google_get_groups.assert_called_once()
+    mock_GoogleGroups.get.assert_called_once_with(format=Format.BASIC)
 
 
 @pytest.mark.parametrize("format", set(FORMATS.values()))
-def test_google__format(mock_google_get_groups, format):
+def test_google__format(mock_GoogleGroups, format):
     google(format=format)
 
-    mock_google_get_groups.assert_called_once_with(format=format)
+    mock_GoogleGroups.get.assert_called_once_with(format=format)
 
 
 def test_toggl(mock_toggl_api, capfd):

--- a/tests/commands/ls/test_init.py
+++ b/tests/commands/ls/test_init.py
@@ -1,0 +1,11 @@
+import pytest
+
+from compiler_admin.commands.ls import ls
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["groups", "orgs", "users"],
+)
+def test_user_commands(command):
+    assert command in ls.commands

--- a/tests/commands/ls/test_orgs.py
+++ b/tests/commands/ls/test_orgs.py
@@ -5,13 +5,14 @@ from compiler_admin.commands.ls.orgs import __name__ as MODULE, orgs
 
 
 @pytest.fixture
-def mock_google_get_org_units(mocker):
-    return mocker.patch(f"{MODULE}.get_org_units")
+def mock_GoogleOrgs(mocker):
+    return mocker.patch(f"{MODULE}.GoogleOrgs").return_value
 
 
-def test_orgs(cli_runner, mock_google_get_org_units):
+def test_orgs(cli_runner, mock_GoogleOrgs):
     args = []
     result = cli_runner.invoke(orgs, args)
 
     assert result.exit_code == Result.SUCCESS
-    mock_google_get_org_units.assert_called_once_with()
+
+    mock_GoogleOrgs.get.assert_called_once_with()

--- a/tests/commands/ls/test_users.py
+++ b/tests/commands/ls/test_users.py
@@ -38,8 +38,8 @@ MOCK_USERS = [
 
 
 @pytest.fixture
-def mock_google_get_users(mocker):
-    return mocker.patch(f"{MODULE}.get_users")
+def mock_GoogleUsers(mocker):
+    return mocker.patch(f"{MODULE}.GoogleUsers").return_value
 
 
 @pytest.fixture
@@ -139,16 +139,16 @@ def test_users__account_type__unknown(cli_runner):
     assert "Invalid value for '-t' / '--account_type': 'unknown'" in result.output
 
 
-def test_google(mock_google_get_users):
+def test_google(mock_GoogleUsers):
     google()
 
-    mock_google_get_users.assert_called_once()
+    mock_GoogleUsers.get.assert_called_once_with(format=Format.BASIC, inactive=False, org_units=[])
 
 
-def test_google__account_type(mock_google_get_users):
+def test_google__account_type(mock_GoogleUsers):
     google(account_type="service_accounts")
 
-    mock_google_get_users.assert_called_once_with(format=Format.BASIC, inactive=False, org_units=["/service-accounts"])
+    mock_GoogleUsers.get.assert_called_once_with(format=Format.BASIC, inactive=False, org_units=["/service-accounts"])
 
 
 def test_google__account_type__unknown():
@@ -157,10 +157,17 @@ def test_google__account_type__unknown():
 
 
 @pytest.mark.parametrize("format", set(FORMATS.values()))
-def test_google__format(mock_google_get_users, format):
+def test_google__format(mock_GoogleUsers, format):
     google(format=format)
 
-    mock_google_get_users.assert_called_once_with(inactive=False, format=format, org_units=[])
+    mock_GoogleUsers.get.assert_called_once_with(format=format, inactive=False, org_units=[])
+
+
+@pytest.mark.parametrize("inactive", (True, False))
+def test_google__inactive(mock_GoogleUsers, inactive):
+    google(inactive=inactive)
+
+    mock_GoogleUsers.get.assert_called_once_with(format=Format.BASIC, inactive=inactive, org_units=[])
 
 
 def test_toggl(mock_toggl_api, capfd):

--- a/tests/commands/test_info.py
+++ b/tests/commands/test_info.py
@@ -5,19 +5,15 @@ from compiler_admin.commands.info import __name__ as MODULE, info
 
 
 @pytest.fixture
-def mock_google_CallGAMCommand(mock_google_CallGAMCommand):
-    return mock_google_CallGAMCommand(MODULE)
+def mock_GoogleService(mocker):
+    return mocker.patch(f"{MODULE}.GoogleService").return_value
 
 
-@pytest.fixture
-def mock_google_CallGYBCommand(mock_google_CallGYBCommand):
-    return mock_google_CallGYBCommand(MODULE)
-
-
-def test_info(cli_runner, mock_google_CallGAMCommand, mock_google_CallGYBCommand):
+def test_info(cli_runner, mock_GoogleService):
     result = cli_runner.invoke(info)
 
     assert result.exit_code == Result.SUCCESS
     assert f"compiler-admin, version {__version__}" in result.output
-    assert mock_google_CallGAMCommand.call_count > 0
-    mock_google_CallGYBCommand.assert_called_once()
+
+    assert mock_GoogleService.gam_command.call_count == 2
+    mock_GoogleService.gyb_command.assert_called_once()

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -25,8 +25,8 @@ def mock_clean_config_dir(mocker):
 
 
 @pytest.fixture
-def mock_google_CallGAMCommand(mock_google_CallGAMCommand):
-    return mock_google_CallGAMCommand(MODULE)
+def mock_GoogleUsers(mocker):
+    return mocker.patch(f"{MODULE}.GoogleUsers").return_value
 
 
 @pytest.fixture
@@ -52,22 +52,21 @@ def test_clean_config_dir(mocker, mock_GAM_CONFIG_PATH, mock_rmtree):
     assert mock_dir in mock_rmtree.call_args.args
 
 
-def test_init_default(cli_runner, mock_clean_config_dir, mock_google_CallGAMCommand, mock_subprocess_call):
+def test_init_default(cli_runner, mock_clean_config_dir, mock_subprocess_call):
     result = cli_runner.invoke(init, ["username"])
 
     assert result.exit_code == Result.SUCCESS
-    assert mock_clean_config_dir.call_count == 0
-    assert mock_google_CallGAMCommand.call_count == 0
-    assert mock_subprocess_call.call_count == 0
+    mock_clean_config_dir.assert_not_called()
+    mock_subprocess_call.assert_not_called()
 
 
-def test_init_gam(cli_runner, mock_GAM_CONFIG_PATH, mock_clean_config_dir, mock_google_CallGAMCommand):
+def test_init_gam(cli_runner, mock_GAM_CONFIG_PATH, mock_clean_config_dir, mock_GoogleUsers):
     result = cli_runner.invoke(init, ["--gam", "username"])
 
     assert result.exit_code == Result.SUCCESS
     mock_clean_config_dir.assert_called_once()
     assert mock_GAM_CONFIG_PATH in mock_clean_config_dir.call_args.args
-    assert mock_google_CallGAMCommand.call_count > 0
+    assert mock_GoogleUsers.gam_command.call_count == 4
 
 
 def test_init_gyb(cli_runner, mock_GYB_CONFIG_PATH, mock_clean_config_dir, mock_subprocess_call):

--- a/tests/commands/user/test_backupcodes.py
+++ b/tests/commands/user/test_backupcodes.py
@@ -5,29 +5,27 @@ from compiler_admin.commands.user.backupcodes import __name__ as MODULE, backupc
 
 
 @pytest.fixture
-def mock_google_user_exists(mock_google_user_exists):
-    return mock_google_user_exists(MODULE)
+def mock_GoogleAccount(mocker):
+    return mocker.patch(f"{MODULE}.GoogleAccount").return_value
 
 
-@pytest.fixture
-def mock_get_backup_codes(mocker):
-    return mocker.patch(f"{MODULE}.get_backup_codes")
-
-
-def test_backupcodes_user_does_not_exist(cli_runner, mock_google_user_exists, mock_get_backup_codes):
-    mock_google_user_exists.return_value = False
+def test_backupcodes_user_does_not_exist(cli_runner, mock_account_exists, mock_GoogleAccount):
+    mock_account_exists(mock_GoogleAccount, False)
 
     result = cli_runner.invoke(backupcodes, ["username"])
 
     assert result.exit_code == Result.FAILURE
-    mock_get_backup_codes.assert_not_called()
+    assert "User does not exist" in result.output
+    mock_GoogleAccount.get_backup_codes.assert_not_called()
 
 
-def test_backupcodes_user_exists(cli_runner, mock_google_user_exists, mock_get_backup_codes):
-    mock_google_user_exists.return_value = True
-    mock_get_backup_codes.return_value = "1234"
+def test_backupcodes_user_exists(cli_runner, mock_account_exists, mock_GoogleAccount):
+    mock_account_exists(mock_GoogleAccount, True)
+    codes = "123456789"
+    mock_GoogleAccount.get_backup_codes.return_value = codes
 
     result = cli_runner.invoke(backupcodes, ["username"])
 
     assert result.exit_code == Result.SUCCESS
-    mock_get_backup_codes.assert_called_once()
+    assert codes in result.output
+    mock_GoogleAccount.get_backup_codes.assert_called_once()

--- a/tests/commands/user/test_convert.py
+++ b/tests/commands/user/test_convert.py
@@ -5,166 +5,213 @@ from compiler_admin.commands.user.convert import __name__ as MODULE, convert
 
 
 @pytest.fixture
-def mock_google_user_exists(mock_google_user_exists):
-    return mock_google_user_exists(MODULE)
+def mock_GoogleAccount(mocker):
+    return mocker.patch(f"{MODULE}.GoogleAccount").return_value
 
 
 @pytest.fixture
-def mock_google_user_exists_true(mock_google_user_exists):
-    mock_google_user_exists.return_value = True
-    return mock_google_user_exists
+def mock_GoogleGroups(mocker):
+    return mocker.patch(f"{MODULE}.GoogleGroups").return_value
 
 
 @pytest.fixture
-def mock_google_add_user_to_group(mock_google_add_user_to_group):
-    return mock_google_add_user_to_group(MODULE)
+def mock_GoogleOrgs(mocker):
+    return mocker.patch(f"{MODULE}.GoogleOrgs").return_value
 
 
 @pytest.fixture
-def mock_google_move_user_ou(mock_google_move_user_ou):
-    return mock_google_move_user_ou(MODULE)
+def mock_google_OU_CONTRACTORS(mock_GoogleOrgs):
+    mock_GoogleOrgs.OU_CONTRACTORS = "/org"
+    mock_GoogleOrgs.__getitem__.return_value = "/org"
+    return mock_GoogleOrgs
 
 
 @pytest.fixture
-def mock_google_remove_user_from_group(mock_google_remove_user_from_group):
-    return mock_google_remove_user_from_group(MODULE)
+def mock_google_OU_PARTNERS(mock_GoogleOrgs):
+    mock_GoogleOrgs.OU_PARTNERS = "/org"
+    mock_GoogleOrgs.__getitem__.return_value = "/org"
+    return mock_GoogleOrgs
 
 
 @pytest.fixture
-def mock_google_user_is_partner(mock_google_user_is_partner):
-    return mock_google_user_is_partner(MODULE)
+def mock_google_OU_STAFF(mock_GoogleOrgs):
+    mock_GoogleOrgs.OU_STAFF = "/org"
+    mock_GoogleOrgs.__getitem__.return_value = "/org"
+    return mock_GoogleOrgs
+
+
+@pytest.fixture(autouse=True)
+def mock_google_user_exists_true(mock_GoogleAccount, mock_account_exists):
+    mock_account_exists(mock_GoogleAccount, True)
 
 
 @pytest.fixture
-def mock_google_user_is_partner_true(mock_google_user_is_partner):
-    mock_google_user_is_partner.return_value = True
-    return mock_google_user_is_partner
+def mock_google_user_is_partner_false(mock_GoogleAccount):
+    mock_GoogleAccount.is_partner.return_value = False
+    return mock_GoogleAccount
 
 
 @pytest.fixture
-def mock_google_user_is_partner_false(mock_google_user_is_partner):
-    mock_google_user_is_partner.return_value = False
-    return mock_google_user_is_partner
+def mock_google_user_is_partner_true(mock_GoogleAccount):
+    mock_GoogleAccount.is_partner.return_value = True
+    return mock_GoogleAccount
 
 
 @pytest.fixture
-def mock_google_user_is_staff(mock_google_user_is_staff):
-    return mock_google_user_is_staff(MODULE)
+def mock_google_user_is_staff_false(mock_GoogleAccount):
+    mock_GoogleAccount.is_staff.return_value = False
+    return mock_GoogleAccount
 
 
 @pytest.fixture
-def mock_google_user_is_staff_true(mock_google_user_is_staff):
-    mock_google_user_is_staff.return_value = True
-    return mock_google_user_is_staff
+def mock_google_user_is_staff_true(mock_GoogleAccount):
+    mock_GoogleAccount.is_staff.return_value = True
+    return mock_GoogleAccount
 
 
-@pytest.fixture
-def mock_google_user_is_staff_false(mock_google_user_is_staff):
-    mock_google_user_is_staff.return_value = False
-    return mock_google_user_is_staff
-
-
-def test_convert_user_does_not_exists(cli_runner, mock_google_user_exists, mock_google_move_user_ou):
-    mock_google_user_exists.return_value = False
+def test_convert__user_does_not_exists(cli_runner, mock_account_exists, mock_GoogleAccount, mock_GoogleOrgs):
+    mock_account_exists(mock_GoogleAccount, False)
 
     result = cli_runner.invoke(convert, ["username", "staff"])
 
     assert result.exit_code != Result.SUCCESS
-    assert mock_google_move_user_ou.call_count == 0
+    mock_GoogleOrgs.gam_command.assert_not_called()
 
 
 @pytest.mark.usefixtures("mock_google_user_exists_true")
-def test_convert_user_exists_bad_account_type(cli_runner, mock_google_move_user_ou):
+def test_convert__user_exists__bad_account_type(cli_runner, mock_GoogleOrgs):
     result = cli_runner.invoke(convert, ["username", "bad_account_type"])
 
     assert result.exit_code != Result.SUCCESS
-    assert mock_google_move_user_ou.call_count == 0
+    assert mock_GoogleOrgs.call_count == 0
 
 
 @pytest.mark.usefixtures(
-    "mock_google_user_exists_true", "mock_google_user_is_partner_false", "mock_google_user_is_staff_false"
+    "mock_google_user_exists_true",
+    "mock_google_user_is_partner_false",
+    "mock_google_user_is_staff_false",
+    "mock_google_OU_CONTRACTORS",
 )
-def test_convert_contractor(cli_runner, mock_google_move_user_ou):
+def test_convert__contractor(cli_runner, mock_GoogleGroups, mock_GoogleOrgs):
     result = cli_runner.invoke(convert, ["username", "contractors"])
 
     assert result.exit_code == Result.SUCCESS
-    mock_google_move_user_ou.assert_called_once()
-
-
-@pytest.mark.usefixtures("mock_google_user_exists_true", "mock_google_user_is_partner_true", "mock_google_user_is_staff_false")
-def test_convert_contractor_user_is_partner(cli_runner, mock_google_remove_user_from_group, mock_google_move_user_ou):
-    result = cli_runner.invoke(convert, ["username", "contractors"])
-
-    assert result.exit_code == Result.SUCCESS
-    assert mock_google_remove_user_from_group.call_count == 2
-    mock_google_move_user_ou.assert_called_once()
-
-
-@pytest.mark.usefixtures("mock_google_user_exists_true", "mock_google_user_is_partner_false", "mock_google_user_is_staff_true")
-def test_convert_contractor_user_is_staff(cli_runner, mock_google_remove_user_from_group, mock_google_move_user_ou):
-    result = cli_runner.invoke(convert, ["username", "contractors"])
-
-    assert result.exit_code == Result.SUCCESS
-    mock_google_remove_user_from_group.assert_called_once()
-    mock_google_move_user_ou.assert_called_once()
+    mock_GoogleOrgs.move_user.assert_called_once()
+    mock_GoogleGroups.add_user.assert_not_called()
 
 
 @pytest.mark.usefixtures(
-    "mock_google_user_exists_true", "mock_google_user_is_partner_false", "mock_google_user_is_staff_false"
+    "mock_google_user_exists_true",
+    "mock_google_user_is_partner_true",
+    "mock_google_user_is_staff_false",
+    "mock_google_OU_CONTRACTORS",
 )
-def test_convert_staff(cli_runner, mock_google_add_user_to_group, mock_google_move_user_ou):
+def test_convert__contractor__user_is_partner(cli_runner, mock_GoogleGroups, mock_GoogleOrgs):
+    result = cli_runner.invoke(convert, ["username", "contractors"])
+
+    assert result.exit_code == Result.SUCCESS
+    assert mock_GoogleGroups.remove_user.call_count == 2
+    mock_GoogleOrgs.move_user.assert_called_once()
+
+
+@pytest.mark.usefixtures(
+    "mock_google_user_exists_true",
+    "mock_google_user_is_partner_false",
+    "mock_google_user_is_staff_true",
+    "mock_google_OU_CONTRACTORS",
+)
+def test_convert__contractor__user_is_staff(cli_runner, mock_GoogleGroups, mock_GoogleOrgs):
+    result = cli_runner.invoke(convert, ["username", "contractors"])
+
+    assert result.exit_code == Result.SUCCESS
+    assert mock_GoogleGroups.remove_user.call_count == 1
+    mock_GoogleOrgs.move_user.assert_called_once()
+
+
+@pytest.mark.usefixtures(
+    "mock_google_user_exists_true",
+    "mock_google_user_is_partner_false",
+    "mock_google_user_is_staff_false",
+    "mock_google_OU_STAFF",
+)
+def test_convert__staff(cli_runner, mock_GoogleGroups, mock_GoogleOrgs):
     result = cli_runner.invoke(convert, ["username", "staff"])
 
     assert result.exit_code == Result.SUCCESS
-    mock_google_add_user_to_group.assert_called_once()
-    mock_google_move_user_ou.assert_called_once()
+    mock_GoogleGroups.add_user.assert_called_once()
+    mock_GoogleOrgs.move_user.assert_called_once()
 
 
-@pytest.mark.usefixtures("mock_google_user_exists_true", "mock_google_user_is_partner_true", "mock_google_user_is_staff_false")
-def test_convert_staff_user_is_partner(
-    cli_runner, mock_google_add_user_to_group, mock_google_remove_user_from_group, mock_google_move_user_ou
-):
+@pytest.mark.usefixtures(
+    "mock_google_user_exists_true",
+    "mock_google_user_is_partner_true",
+    "mock_google_user_is_staff_false",
+    "mock_google_OU_STAFF",
+)
+def test_convert__staff__user_is_partner(cli_runner, mock_GoogleGroups, mock_GoogleOrgs):
     result = cli_runner.invoke(convert, ["username", "staff"])
 
     assert result.exit_code == Result.SUCCESS
-    mock_google_remove_user_from_group.assert_called_once()
-    mock_google_add_user_to_group.assert_called_once()
-    mock_google_move_user_ou.assert_called_once()
+    mock_GoogleGroups.remove_user.assert_called_once()
+    mock_GoogleGroups.add_user.assert_called_once()
+    mock_GoogleOrgs.move_user.assert_called_once()
 
 
-@pytest.mark.usefixtures("mock_google_user_exists_true", "mock_google_user_is_partner_false", "mock_google_user_is_staff_true")
-def test_convert_staff_user_is_staff(cli_runner, mock_google_add_user_to_group, mock_google_move_user_ou):
+@pytest.mark.usefixtures(
+    "mock_google_user_exists_true",
+    "mock_google_user_is_partner_false",
+    "mock_google_user_is_staff_true",
+    "mock_google_OU_STAFF",
+)
+def test_convert__staff__user_is_staff(cli_runner, mock_GoogleGroups, mock_GoogleOrgs):
     result = cli_runner.invoke(convert, ["username", "staff"])
 
     assert result.exit_code != Result.SUCCESS
-    assert mock_google_add_user_to_group.call_count == 0
-    assert mock_google_move_user_ou.call_count == 0
+    assert "User is already staff" in result.output
+    mock_GoogleGroups.add_user.assert_not_called()
+    mock_GoogleGroups.remove_user.assert_not_called()
+    mock_GoogleOrgs.move_user.assert_not_called()
 
 
 @pytest.mark.usefixtures(
-    "mock_google_user_exists_true", "mock_google_user_is_partner_false", "mock_google_user_is_staff_false"
+    "mock_google_user_exists_true",
+    "mock_google_user_is_partner_false",
+    "mock_google_user_is_staff_false",
+    "mock_google_OU_PARTNERS",
 )
-def test_convert_partner(cli_runner, mock_google_add_user_to_group, mock_google_move_user_ou):
+def test_convert__partner(cli_runner, mock_GoogleGroups, mock_GoogleOrgs):
     result = cli_runner.invoke(convert, ["username", "partners"])
 
     assert result.exit_code == Result.SUCCESS
-    assert mock_google_add_user_to_group.call_count == 2
-    mock_google_move_user_ou.assert_called_once()
+    assert mock_GoogleGroups.add_user.call_count == 2
+    mock_GoogleOrgs.move_user.assert_called_once()
 
 
-@pytest.mark.usefixtures("mock_google_user_exists_true", "mock_google_user_is_partner_true", "mock_google_user_is_staff_false")
-def test_convert_partner_user_is_partner(cli_runner, mock_google_add_user_to_group, mock_google_move_user_ou):
+@pytest.mark.usefixtures(
+    "mock_google_user_exists_true",
+    "mock_google_user_is_partner_true",
+    "mock_google_user_is_staff_false",
+    "mock_google_OU_PARTNERS",
+)
+def test_convert__partner__user_is_partner(cli_runner, mock_GoogleGroups, mock_GoogleOrgs):
     result = cli_runner.invoke(convert, ["username", "partners"])
 
-    assert result != Result.SUCCESS
-    assert mock_google_add_user_to_group.call_count == 0
-    assert mock_google_move_user_ou.call_count == 0
+    assert result.exit_code != Result.SUCCESS
+    assert "User is already partner" in result.output
+    mock_GoogleGroups.add_user.assert_not_called()
+    mock_GoogleGroups.remove_user.assert_not_called()
+    mock_GoogleOrgs.move_user.assert_not_called()
 
 
-@pytest.mark.usefixtures("mock_google_user_exists_true", "mock_google_user_is_partner_false", "mock_google_user_is_staff_true")
-def test_convert_partner_user_is_staff(cli_runner, mock_google_add_user_to_group, mock_google_move_user_ou):
+@pytest.mark.usefixtures(
+    "mock_google_user_exists_true",
+    "mock_google_user_is_partner_false",
+    "mock_google_user_is_staff_true",
+    "mock_google_OU_PARTNERS",
+)
+def test_convert__partner__user_is_staff(cli_runner, mock_GoogleGroups, mock_GoogleOrgs):
     result = cli_runner.invoke(convert, ["username", "partners"])
 
     assert result.exit_code == Result.SUCCESS
-    mock_google_add_user_to_group.assert_called_once()
-    mock_google_move_user_ou.assert_called_once()
+    mock_GoogleGroups.add_user.assert_called_once()
+    mock_GoogleOrgs.move_user.assert_called_once()

--- a/tests/commands/user/test_create.py
+++ b/tests/commands/user/test_create.py
@@ -2,76 +2,64 @@ import pytest
 
 from compiler_admin import Result
 from compiler_admin.commands.user.create import __name__ as MODULE, create
-from compiler_admin.services.google import USER_HELLO
 
 
 @pytest.fixture
-def mock_google_user_exists(mock_google_user_exists):
-    return mock_google_user_exists(MODULE)
+def mock_GoogleAccount(mocker):
+    return mocker.patch(f"{MODULE}.GoogleAccount").return_value
 
 
 @pytest.fixture
-def mock_google_CallGAMCommand(mock_google_CallGAMCommand):
-    return mock_google_CallGAMCommand(MODULE)
+def mock_GoogleGroups(mocker):
+    return mocker.patch(f"{MODULE}.GoogleGroups").return_value
 
 
 @pytest.fixture
-def mock_google_add_user_to_group(mock_google_add_user_to_group):
-    return mock_google_add_user_to_group(MODULE)
+def mock_GoogleOrgs(mocker):
+    return mocker.patch(f"{MODULE}.GoogleOrgs").return_value
 
 
-def test_create_user_exists(cli_runner, mock_google_user_exists):
-    mock_google_user_exists.return_value = True
+@pytest.fixture
+def mock_GoogleUsers(mocker):
+    return mocker.patch(f"{MODULE}.GoogleUsers").return_value
+
+
+def test_create__user_exists(cli_runner, mock_account_exists, mock_GoogleAccount):
+    mock_account_exists(mock_GoogleAccount, True)
 
     result = cli_runner.invoke(create, ["username"])
 
     assert result.exit_code != Result.SUCCESS
+    assert "User already exists" in result.output
 
 
-def test_create_user_does_not_exists(
-    cli_runner, mock_google_user_exists, mock_google_CallGAMCommand, mock_google_add_user_to_group
+def test_create__user_does_not_exists(
+    cli_runner, mock_account_exists, mock_GoogleAccount, mock_GoogleGroups, mock_GoogleUsers
 ):
-    mock_google_user_exists.return_value = False
+    mock_account_exists(mock_GoogleAccount, False)
 
     result = cli_runner.invoke(create, ["username"])
 
     assert result.exit_code == Result.SUCCESS
-
-    mock_google_CallGAMCommand.assert_called_once()
-    call_args = " ".join(mock_google_CallGAMCommand.call_args[0][0])
-    assert "create user" in call_args
-    assert "password random changepassword" in call_args
-
-    mock_google_add_user_to_group.assert_called_once()
+    mock_GoogleUsers.create.assert_called_once_with(mock_GoogleAccount, None)
+    mock_GoogleGroups.add_user.assert_called_once()
 
 
-def test_create_user_notify(cli_runner, mock_google_user_exists, mock_google_CallGAMCommand, mock_google_add_user_to_group):
-    mock_google_user_exists.return_value = False
+def test_create__notify(cli_runner, mock_account_exists, mock_GoogleAccount, mock_GoogleGroups, mock_GoogleUsers):
+    mock_account_exists(mock_GoogleAccount, False)
 
     result = cli_runner.invoke(create, ["--notify", "notification@example.com", "username"])
 
     assert result.exit_code == Result.SUCCESS
-
-    mock_google_CallGAMCommand.assert_called_once()
-    call_args = " ".join(mock_google_CallGAMCommand.call_args[0][0])
-    assert "create user" in call_args
-    assert "password random changepassword" in call_args
-    assert f"notify notification@example.com from {USER_HELLO}" in call_args
-
-    mock_google_add_user_to_group.assert_called_once()
+    mock_GoogleUsers.create.assert_called_once_with(mock_GoogleAccount, "notification@example.com")
+    mock_GoogleGroups.add_user.assert_called_once()
 
 
-def test_create_user_extras(cli_runner, mock_google_user_exists, mock_google_CallGAMCommand, mock_google_add_user_to_group):
-    mock_google_user_exists.return_value = False
+def test_create__extras(cli_runner, mock_account_exists, mock_GoogleAccount, mock_GoogleGroups, mock_GoogleUsers):
+    mock_account_exists(mock_GoogleAccount, False)
 
     result = cli_runner.invoke(create, ["username", "extra1", "extra2"])
 
     assert result.exit_code == Result.SUCCESS
-
-    mock_google_CallGAMCommand.assert_called_once()
-    call_args = " ".join(mock_google_CallGAMCommand.call_args[0][0])
-    assert "create user" in call_args
-    assert "password random changepassword" in call_args
-    assert "extra1 extra2" in call_args
-
-    mock_google_add_user_to_group.assert_called_once()
+    mock_GoogleUsers.create.assert_called_once_with(mock_GoogleAccount, None, "extra1", "extra2")
+    mock_GoogleGroups.add_user.assert_called_once()

--- a/tests/commands/user/test_deactivate.py
+++ b/tests/commands/user/test_deactivate.py
@@ -2,12 +2,13 @@ import pytest
 
 from compiler_admin import Result
 from compiler_admin.commands.user.deactivate import __name__ as MODULE, deactivate
-from compiler_admin.services.google import OU_ALUMNI
+from compiler_admin.commands.user.reset import reset
 
 
 @pytest.fixture
-def mock_commands_reset(mock_commands_reset):
-    return mock_commands_reset(MODULE)
+def mock_ctx_forward(mocker):
+    """Mock click.Context.forward."""
+    return mocker.patch("click.Context.forward")
 
 
 @pytest.fixture
@@ -21,69 +22,95 @@ def mock_input_no(mock_input_no):
 
 
 @pytest.fixture
-def mock_google_CallGAMCommand(mock_google_CallGAMCommand):
-    return mock_google_CallGAMCommand(MODULE)
+def mock_GoogleAccount(mocker):
+    mock = mocker.patch(f"{MODULE}.GoogleAccount").return_value
+    mock.is_deactivated.return_value = False
+    return mock
 
 
 @pytest.fixture
-def mock_google_move_user_ou(mock_google_move_user_ou):
-    return mock_google_move_user_ou(MODULE)
+def mock_GoogleOrgs(mocker):
+    return mocker.patch(f"{MODULE}.GoogleOrgs")
 
 
 @pytest.fixture
-def mock_google_remove_user_from_group(mock_google_remove_user_from_group):
-    return mock_google_remove_user_from_group(MODULE)
+def mock_GoogleUsers(mocker):
+    return mocker.patch(f"{MODULE}.GoogleUsers").return_value
 
 
-@pytest.fixture
-def mock_google_user_exists(mock_google_user_exists):
-    return mock_google_user_exists(MODULE)
-
-
-def test_deactivate_user_does_not_exists(cli_runner, mock_google_user_exists, mock_google_CallGAMCommand):
-    mock_google_user_exists.return_value = False
+def test_deactivate__user_does_not_exists(cli_runner, mock_account_exists, mock_GoogleAccount):
+    mock_account_exists(mock_GoogleAccount, False)
 
     result = cli_runner.invoke(deactivate, ["username"])
 
-    assert result.exit_code == Result.FAILURE
+    assert result.exit_code != Result.SUCCESS
     assert result.exception
-    assert "User does not exist: username@compiler.la" in result.output
-    mock_google_CallGAMCommand.assert_not_called()
+    assert "User does not exist" in result.output
+
+
+def test_deactivate__user_deactivated(cli_runner, mock_account_exists, mock_GoogleAccount):
+    mock_account_exists(mock_GoogleAccount, True)
+    mock_GoogleAccount.is_deactivated.return_value = True
+
+    result = cli_runner.invoke(deactivate, ["username"])
+
+    assert result.exit_code != Result.SUCCESS
+    assert result.exception
+    assert "User is already deactivated" in result.output
 
 
 @pytest.mark.usefixtures("mock_input_yes")
-def test_deactivate_confirm_yes(
-    cli_runner, mock_google_user_exists, mock_google_CallGAMCommand, mock_google_move_user_ou, mock_commands_reset
+def test_deactivate__confirm_yes(
+    cli_runner, mocker, mock_account_exists, mock_ctx_forward, mock_GoogleAccount, mock_GoogleOrgs, mock_GoogleUsers
 ):
-    mock_google_user_exists.return_value = True
+    mock_account_exists(mock_GoogleAccount, True)
+    mock_orgs = mock_GoogleOrgs.return_value
 
     result = cli_runner.invoke(deactivate, ["username"])
 
     assert result.exit_code == Result.SUCCESS
-    mock_google_CallGAMCommand.assert_called()
-    mock_google_move_user_ou.assert_called_once_with("username@compiler.la", OU_ALUMNI)
+    mock_orgs.move_user.assert_called_once_with(mock_GoogleAccount, mock_GoogleOrgs.OU_ALUMNI)
+    mock_GoogleUsers.remove_from_groups.assert_called_once_with(mock_GoogleAccount)
+    assert mocker.call(reset) in mock_ctx_forward.mock_calls
+    mock_GoogleUsers.clear_profile.assert_called_once_with(mock_GoogleAccount)
+    mock_GoogleUsers.reset_recovery_info.assert_called_once_with(
+        account=mock_GoogleAccount, recovery_email="", recovery_phone=""
+    )
+    mock_GoogleUsers.disable_2fa.assert_called_once_with(mock_GoogleAccount)
 
 
 @pytest.mark.usefixtures("mock_input_no")
-def test_deactivate_confirm_no(
-    cli_runner, mock_google_user_exists, mock_google_CallGAMCommand, mock_google_move_user_ou, mock_commands_reset
+def test_deactivate__confirm_no(
+    cli_runner, mock_account_exists, mock_ctx_forward, mock_GoogleAccount, mock_GoogleOrgs, mock_GoogleUsers
 ):
-    mock_google_user_exists.return_value = True
+    mock_account_exists(mock_GoogleAccount, True)
+    mock_orgs = mock_GoogleOrgs.return_value
 
     result = cli_runner.invoke(deactivate, ["username"])
 
     assert result.exit_code == Result.SUCCESS
-    mock_google_CallGAMCommand.assert_not_called()
-    mock_google_move_user_ou.assert_not_called()
+    mock_orgs.move_user.assert_not_called()
+    mock_GoogleUsers.remove_from_groups.assert_not_called()
+    mock_ctx_forward.assert_not_called()
+    mock_GoogleUsers.clear_profile.assert_not_called()
+    mock_GoogleUsers.reset_recovery_info.assert_not_called()
+    mock_GoogleUsers.disable_2fa.assert_not_called()
 
 
-def test_deactivate_force(
-    cli_runner, mock_google_user_exists, mock_google_CallGAMCommand, mock_google_move_user_ou, mock_commands_reset
+def test_deactivate__force(
+    cli_runner, mocker, mock_account_exists, mock_ctx_forward, mock_GoogleAccount, mock_GoogleOrgs, mock_GoogleUsers
 ):
-    mock_google_user_exists.return_value = True
+    mock_account_exists(mock_GoogleAccount, True)
+    mock_orgs = mock_GoogleOrgs.return_value
 
-    result = cli_runner.invoke(deactivate, ["--force", "username"])
+    result = cli_runner.invoke(deactivate, ["username", "--force"])
 
     assert result.exit_code == Result.SUCCESS
-    mock_google_CallGAMCommand.assert_called()
-    mock_google_move_user_ou.assert_called_once_with("username@compiler.la", OU_ALUMNI)
+    mock_orgs.move_user.assert_called_once_with(mock_GoogleAccount, mock_GoogleOrgs.OU_ALUMNI)
+    mock_GoogleUsers.remove_from_groups.assert_called_once_with(mock_GoogleAccount)
+    assert mocker.call(reset) in mock_ctx_forward.mock_calls
+    mock_GoogleUsers.clear_profile.assert_called_once_with(mock_GoogleAccount)
+    mock_GoogleUsers.reset_recovery_info.assert_called_once_with(
+        account=mock_GoogleAccount, recovery_email="", recovery_phone=""
+    )
+    mock_GoogleUsers.disable_2fa.assert_called_once_with(mock_GoogleAccount)

--- a/tests/commands/user/test_delete.py
+++ b/tests/commands/user/test_delete.py
@@ -15,43 +15,49 @@ def mock_input_no(mock_input_no):
 
 
 @pytest.fixture
-def mock_google_user_exists(mock_google_user_exists):
-    return mock_google_user_exists(MODULE)
+def mock_GoogleAccount(mocker):
+    return mocker.patch(f"{MODULE}.GoogleAccount").return_value
 
 
 @pytest.fixture
-def mock_google_CallGAMCommand(mock_google_CallGAMCommand):
-    return mock_google_CallGAMCommand(MODULE)
-
-
-@pytest.mark.usefixtures("mock_input_yes")
-def test_delete_confirm_yes(cli_runner, mock_google_user_exists, mock_google_CallGAMCommand):
-    mock_google_user_exists.return_value = True
-
-    result = cli_runner.invoke(delete, ["username"])
-
-    assert result.exit_code == Result.SUCCESS
-    mock_google_CallGAMCommand.assert_called_once()
-    call_args = mock_google_CallGAMCommand.call_args.args[0]
-    assert "delete" in call_args
-    assert "user" in call_args
-    assert "noactionifalias" in call_args
+def mock_GoogleUsers(mocker):
+    return mocker.patch(f"{MODULE}.GoogleUsers").return_value
 
 
 @pytest.mark.usefixtures("mock_input_no")
-def test_delete_confirm_no(cli_runner, mock_google_user_exists, mock_google_CallGAMCommand):
-    mock_google_user_exists.return_value = True
+def test_delete__confirm_no(cli_runner, mock_account_exists, mock_GoogleAccount, mock_GoogleUsers):
+    mock_account_exists(mock_GoogleAccount, True)
 
     result = cli_runner.invoke(delete, ["username"])
 
     assert result.exit_code == Result.SUCCESS
-    mock_google_CallGAMCommand.assert_not_called()
+    mock_GoogleUsers.delete.assert_not_called()
 
 
-def test_delete_user_does_not_exist(cli_runner, mock_google_user_exists, mock_google_CallGAMCommand):
-    mock_google_user_exists.return_value = False
+@pytest.mark.usefixtures("mock_input_yes")
+def test_delete__confirm_yes(cli_runner, mock_account_exists, mock_GoogleAccount, mock_GoogleUsers):
+    mock_account_exists(mock_GoogleAccount, True)
+
+    result = cli_runner.invoke(delete, ["username"])
+
+    assert result.exit_code == Result.SUCCESS
+    mock_GoogleUsers.delete.assert_called_once_with(mock_GoogleAccount)
+
+
+def test_delete__force(cli_runner, mock_account_exists, mock_GoogleAccount, mock_GoogleUsers):
+    mock_account_exists(mock_GoogleAccount, True)
+
+    result = cli_runner.invoke(delete, ["--force", "username"])
+
+    assert result.exit_code == Result.SUCCESS
+    mock_GoogleUsers.delete.assert_called_once_with(mock_GoogleAccount)
+
+
+def test_delete__user_does_not_exist(cli_runner, mock_account_exists, mock_GoogleAccount, mock_GoogleUsers):
+    mock_account_exists(mock_GoogleAccount, False)
 
     result = cli_runner.invoke(delete, ["username"])
 
     assert result.exit_code != Result.SUCCESS
-    assert mock_google_CallGAMCommand.call_count == 0
+    assert "User does not exist" in result.output
+    mock_GoogleUsers.delete.assert_not_called()

--- a/tests/commands/user/test_offboard.py
+++ b/tests/commands/user/test_offboard.py
@@ -1,7 +1,15 @@
 import pytest
 
 from compiler_admin import Result
+from compiler_admin.commands.user.deactivate import deactivate
+from compiler_admin.commands.user.delete import delete
 from compiler_admin.commands.user.offboard import __name__ as MODULE, offboard
+
+
+@pytest.fixture
+def mock_ctx_forward(mocker):
+    """Mock click.Context.forward."""
+    return mocker.patch("click.Context.forward")
 
 
 @pytest.fixture
@@ -15,48 +23,54 @@ def mock_input_no(mock_input_no):
 
 
 @pytest.fixture
-def mock_NamedTemporaryFile(mock_NamedTemporaryFile_with_readlines):
-    return mock_NamedTemporaryFile_with_readlines(MODULE, ["Overall Transfer Status: completed"])
+def mock_GoogleAccount(mocker):
+    return mocker.patch(f"{MODULE}.GoogleAccount").return_value
 
 
 @pytest.fixture
-def mock_commands_deactivate(mock_commands_deactivate):
-    return mock_commands_deactivate(MODULE)
+def mock_GoogleArchive(mocker):
+    return mocker.patch(f"{MODULE}.GoogleArchive").return_value
 
 
 @pytest.fixture
-def mock_commands_delete(mock_commands_delete):
-    return mock_commands_delete(MODULE)
+def mock_GoogleUsers(mocker):
+    return mocker.patch(f"{MODULE}.GoogleUsers").return_value
 
 
-@pytest.fixture
-def mock_google_user_exists(mock_google_user_exists):
-    return mock_google_user_exists(MODULE)
+@pytest.mark.usefixtures("mock_ctx_forward", "mock_input_yes", "mock_GoogleArchive", "mock_GoogleUsers")
+def test_offboard__alias(cli_runner, mock_GoogleAccount):
+    mock_GoogleAccount.exists.return_value = True
+
+    result = cli_runner.invoke(offboard, ["--alias", "alias_username", "username"])
+
+    assert result.exit_code == Result.SUCCESS
+    mock_GoogleAccount.add_email_alias.assert_called_once_with(mock_GoogleAccount)
 
 
-@pytest.fixture
-def mock_google_CallGAMCommand(mock_google_CallGAMCommand):
-    return mock_google_CallGAMCommand(MODULE)
+def test_offboard__alias__user_does_not_exist(cli_runner, mock_GoogleAccount):
+    # the first call returns True (the user exists), the second False (the alias user does not exist)
+    # https://stackoverflow.com/a/24897297
+    mock_GoogleAccount.exists.side_effect = [True, False]
 
+    result = cli_runner.invoke(offboard, ["--alias", "alias_username", "username"])
 
-@pytest.fixture
-def mock_google_CallGYBCommand(mock_google_CallGYBCommand):
-    return mock_google_CallGYBCommand(MODULE)
+    assert result.exit_code != Result.SUCCESS
+    assert "Alias target user does not exist" in result.output
 
 
 @pytest.mark.usefixtures("mock_input_yes")
 @pytest.mark.parametrize("should_delete", [True, False])
-def test_offboard_confirm_yes(
+def test_offboard__confirm_yes(
     cli_runner,
-    mock_google_user_exists,
-    mock_google_CallGAMCommand,
-    mock_google_CallGYBCommand,
-    mock_NamedTemporaryFile,
-    mock_commands_deactivate,
-    mock_commands_delete,
+    mocker,
+    mock_account_exists,
+    mock_ctx_forward,
+    mock_GoogleAccount,
+    mock_GoogleArchive,
+    mock_GoogleUsers,
     should_delete,
 ):
-    mock_google_user_exists.return_value = True
+    mock_account_exists(mock_GoogleAccount, True)
 
     args = ["username"]
     if should_delete:
@@ -65,55 +79,61 @@ def test_offboard_confirm_yes(
     result = cli_runner.invoke(offboard, args)
 
     assert result.exit_code == Result.SUCCESS
-    assert mock_google_CallGAMCommand.call_count > 0
-    mock_google_CallGYBCommand.assert_called_once()
-    mock_NamedTemporaryFile.assert_called_once()
-
-    mock_commands_deactivate.callback.assert_called_once()
+    assert mocker.call(deactivate) in mock_ctx_forward.mock_calls
+    mock_GoogleArchive.create_email_backup.assert_called_once_with(mock_GoogleAccount)
+    mock_GoogleArchive.archive_content.assert_called_once_with(mock_GoogleAccount)
+    mock_GoogleArchive.await_archive_completion.assert_called_once()
+    mock_GoogleUsers.deprovision_popimap.assert_called_once_with(mock_GoogleAccount)
 
     if should_delete:
-        mock_commands_delete.callback.assert_called_once()
+        assert mocker.call(delete) in mock_ctx_forward.mock_calls
     else:
-        mock_commands_delete.callback.assert_not_called()
+        assert mocker.call(delete) not in mock_ctx_forward.mock_calls
 
 
 @pytest.mark.usefixtures("mock_input_no")
-def test_offboard_confirm_no(
-    cli_runner,
-    mock_google_user_exists,
-    mock_google_CallGAMCommand,
-    mock_google_CallGYBCommand,
-    mock_commands_deactivate,
-    mock_commands_delete,
-):
-    mock_google_user_exists.return_value = True
+def test_offboard__confirm_no(cli_runner, mocker, mock_ctx_forward, mock_GoogleAccount, mock_GoogleArchive, mock_GoogleUsers):
+    mock_GoogleAccount.return_value = True
 
     result = cli_runner.invoke(offboard, ["username"])
 
     assert result.exit_code == Result.SUCCESS
-    mock_google_CallGAMCommand.assert_not_called()
-    mock_google_CallGYBCommand.assert_not_called()
+    assert mocker.call(deactivate) not in mock_ctx_forward.mock_calls
+    mock_GoogleArchive.create_email_backup.assert_not_called()
+    mock_GoogleArchive.archive_content.assert_not_called()
+    mock_GoogleArchive.await_archive_completion.assert_not_called()
+    mock_GoogleUsers.deprovision_popimap.assert_not_called()
+    assert mocker.call(delete) not in mock_ctx_forward.mock_calls
 
-    mock_commands_deactivate.callback.assert_not_called()
-    mock_commands_delete.callback.assert_not_called()
+
+def test_offboard__force(
+    cli_runner, mocker, mock_account_exists, mock_ctx_forward, mock_GoogleAccount, mock_GoogleArchive, mock_GoogleUsers
+):
+    mock_account_exists(mock_GoogleAccount, True)
+
+    args = ["username", "--force"]
+    result = cli_runner.invoke(offboard, args)
+
+    assert result.exit_code == Result.SUCCESS
+    assert mocker.call(deactivate) in mock_ctx_forward.mock_calls
+    mock_GoogleArchive.create_email_backup.assert_called_once_with(mock_GoogleAccount)
+    mock_GoogleArchive.archive_content.assert_called_once_with(mock_GoogleAccount)
+    mock_GoogleArchive.await_archive_completion.assert_called_once()
+    mock_GoogleUsers.deprovision_popimap.assert_called_once_with(mock_GoogleAccount)
 
 
-def test_offboard_user_does_not_exist(cli_runner, mock_google_user_exists, mock_google_CallGAMCommand):
-    mock_google_user_exists.return_value = False
+def test_offboard__user_does_not_exist(
+    cli_runner, mocker, mock_account_exists, mock_ctx_forward, mock_GoogleAccount, mock_GoogleArchive, mock_GoogleUsers
+):
+    mock_account_exists(mock_GoogleAccount, False)
 
     result = cli_runner.invoke(offboard, ["username"])
 
     assert result.exit_code != Result.SUCCESS
-    assert mock_google_CallGAMCommand.call_count == 0
-
-
-def test_offboard_alias_user_does_not_exist(cli_runner, mock_google_user_exists, mock_google_CallGAMCommand):
-    # the first call returns True (the user exists), the second False (the alias user does not)
-    # https://stackoverflow.com/a/24897297
-    mock_google_user_exists.side_effect = [True, False]
-
-    result = cli_runner.invoke(offboard, ["--alias", "alias_username", "username"])
-
-    assert result.exit_code != Result.SUCCESS
-    assert mock_google_user_exists.call_count == 2
-    assert mock_google_CallGAMCommand.call_count == 0
+    assert "User does not exist" in result.output
+    assert mocker.call(deactivate) not in mock_ctx_forward.mock_calls
+    mock_GoogleArchive.create_email_backup.assert_not_called()
+    mock_GoogleArchive.archive_content.assert_not_called()
+    mock_GoogleArchive.await_archive_completion.assert_not_called()
+    mock_GoogleUsers.deprovision_popimap.assert_not_called()
+    assert mocker.call(delete) not in mock_ctx_forward.mock_calls

--- a/tests/commands/user/test_reactivate.py
+++ b/tests/commands/user/test_reactivate.py
@@ -1,12 +1,9 @@
-from unittest.mock import call
-
 import pytest
 
 from compiler_admin import Result
 from compiler_admin.commands.user.backupcodes import backupcodes
 from compiler_admin.commands.user.reactivate import __name__ as MODULE, reactivate
 from compiler_admin.commands.user.reset import reset
-from compiler_admin.services.google import GROUP_STAFF, GROUP_TEAM, OU_CONTRACTORS, OU_STAFF
 
 
 @pytest.fixture
@@ -26,147 +23,91 @@ def mock_input_no(mock_input_no):
 
 
 @pytest.fixture
-def mock_google_CallGAMCommand(mock_google_CallGAMCommand):
-    return mock_google_CallGAMCommand(MODULE)
+def mock_GoogleAccount(mocker):
+    return mocker.patch(f"{MODULE}.GoogleAccount").return_value
 
 
 @pytest.fixture
-def mock_google_add_user_to_group(mock_google_add_user_to_group):
-    return mock_google_add_user_to_group(MODULE)
+def mock_GoogleGroups(mocker):
+    return mocker.patch(f"{MODULE}.GoogleGroups").return_value
 
 
 @pytest.fixture
-def mock_google_move_user_ou(mock_google_move_user_ou):
-    return mock_google_move_user_ou(MODULE)
+def mock_GoogleOrgs(mocker):
+    return mocker.patch(f"{MODULE}.GoogleOrgs").return_value
 
 
 @pytest.fixture
-def mock_google_user_exists(mock_google_user_exists):
-    return mock_google_user_exists(MODULE)
+def mock_GoogleUsers(mocker):
+    return mocker.patch(f"{MODULE}.GoogleUsers").return_value
 
 
-@pytest.fixture
-def mock_google_user_is_deactivated(mock_module_name):
-    return mock_module_name("user_is_deactivated")(MODULE)
+@pytest.fixture(autouse=True)
+def mock_account_exists__true(mock_account_exists, mock_GoogleAccount):
+    mock_account_exists(mock_GoogleAccount, True)
+    mock_GoogleAccount.is_deactivated.return_value = True
 
 
-def test_reactivate_user_does_not_exist(cli_runner, mock_google_user_exists, mock_google_CallGAMCommand):
-    mock_google_user_exists.return_value = False
+def test_reactivate_user_does_not_exist(cli_runner, mock_account_exists, mock_GoogleAccount):
+    mock_account_exists(mock_GoogleAccount, False)
 
     result = cli_runner.invoke(reactivate, ["username"])
 
-    assert result.exit_code == Result.FAILURE
-    assert result.exception
-    assert "User does not exist: username@compiler.la" in result.output
-    mock_google_CallGAMCommand.assert_not_called()
+    assert result.exit_code != Result.SUCCESS
+    assert "User does not exist" in result.output
 
 
-def test_reactivate_user_is_not_deactivated(cli_runner, mock_google_user_exists, mock_google_user_is_deactivated):
-    mock_google_user_exists.return_value = True
-    mock_google_user_is_deactivated.return_value = False
+def test_reactivate__user_is_not_deactivated(cli_runner, mock_GoogleAccount):
+    mock_GoogleAccount.is_deactivated.return_value = False
 
     result = cli_runner.invoke(reactivate, ["username"])
 
-    assert result.exit_code == Result.FAILURE
-    assert result.exception
+    assert result.exit_code != Result.SUCCESS
     assert "User is not deactivated, cannot reactivate" in result.output
 
 
 @pytest.mark.usefixtures("mock_input_no")
-def test_reactivate_confirm_no(cli_runner, mock_google_user_exists, mock_google_user_is_deactivated):
-    mock_google_user_exists.return_value = True
-    mock_google_user_is_deactivated.return_value = True
-
+def test_reactivate__confirm_no(cli_runner):
     result = cli_runner.invoke(reactivate, ["username"])
 
     assert result.exit_code == Result.SUCCESS
-    assert not result.exception
     assert "Aborting reactivation" in result.output
 
 
 @pytest.mark.usefixtures("mock_input_yes")
-def test_reactivate_confirm_yes(
-    cli_runner,
-    mock_google_user_exists,
-    mock_google_user_is_deactivated,
-    mock_google_add_user_to_group,
-    mock_google_move_user_ou,
-    mock_ctx_forward,
-):
-    mock_google_user_exists.return_value = True
-    mock_google_user_is_deactivated.return_value = True
-
+def test_reactivate__confirm_yes(mocker, cli_runner, mock_ctx_forward, mock_GoogleAccount, mock_GoogleGroups, mock_GoogleOrgs):
     result = cli_runner.invoke(reactivate, ["username"])
 
     assert result.exit_code == Result.SUCCESS
-    assert not result.exception
-    mock_google_add_user_to_group.assert_called_once_with("username@compiler.la", GROUP_TEAM)
-    mock_google_move_user_ou.assert_called_once_with("username@compiler.la", OU_CONTRACTORS)
-    mock_ctx_forward.assert_has_calls([call(reset), call(backupcodes)])
+    mock_GoogleGroups.add_user.assert_called_once_with(mock_GoogleAccount)
+    mock_GoogleOrgs.move_user.assert_called_once_with(mock_GoogleAccount)
+    mock_ctx_forward.assert_has_calls([mocker.call(reset), mocker.call(backupcodes)])
 
 
-def test_reactivate_force(
-    cli_runner,
-    mock_google_user_exists,
-    mock_google_user_is_deactivated,
-    mock_google_add_user_to_group,
-    mock_google_move_user_ou,
-    mock_ctx_forward,
-):
-    mock_google_user_exists.return_value = True
-    mock_google_user_is_deactivated.return_value = True
-
+def test_reactivate__force(mocker, cli_runner, mock_ctx_forward, mock_GoogleAccount, mock_GoogleGroups, mock_GoogleOrgs):
     result = cli_runner.invoke(reactivate, ["--force", "username"])
 
     assert result.exit_code == Result.SUCCESS
-    assert not result.exception
-    mock_google_add_user_to_group.assert_called_once_with("username@compiler.la", GROUP_TEAM)
-    mock_google_move_user_ou.assert_called_once_with("username@compiler.la", OU_CONTRACTORS)
-    mock_ctx_forward.assert_has_calls([call(reset), call(backupcodes)])
+    mock_GoogleGroups.add_user.assert_called_once_with(mock_GoogleAccount)
+    mock_GoogleOrgs.move_user.assert_called_once_with(mock_GoogleAccount)
+    mock_ctx_forward.assert_has_calls([mocker.call(reset), mocker.call(backupcodes)])
 
 
-def test_reactivate_staff(
-    cli_runner,
-    mock_google_user_exists,
-    mock_google_user_is_deactivated,
-    mock_google_add_user_to_group,
-    mock_google_move_user_ou,
-    mock_ctx_forward,
-):
-    mock_google_user_exists.return_value = True
-    mock_google_user_is_deactivated.return_value = True
-
+def test_reactivate__staff(mocker, cli_runner, mock_ctx_forward, mock_GoogleAccount, mock_GoogleGroups, mock_GoogleOrgs):
     result = cli_runner.invoke(reactivate, ["--force", "--staff", "username"])
 
     assert result.exit_code == Result.SUCCESS
-    assert not result.exception
-    mock_google_add_user_to_group.assert_has_calls(
-        [call("username@compiler.la", GROUP_TEAM), call("username@compiler.la", GROUP_STAFF)]
-    )
-    mock_google_move_user_ou.assert_called_once_with("username@compiler.la", OU_STAFF)
-    mock_ctx_forward.assert_has_calls([call(reset), call(backupcodes)])
+    mock_GoogleGroups.add_user.assert_has_calls([mocker.call(mock_GoogleAccount), mocker.call(mock_GoogleAccount)])
+    mock_GoogleOrgs.move_user.assert_called_once_with(mock_GoogleAccount)
+    mock_ctx_forward.assert_has_calls([mocker.call(reset), mocker.call(backupcodes)])
 
 
-def test_reactivate_recovery_info(
-    cli_runner,
-    mock_google_user_exists,
-    mock_google_user_is_deactivated,
-    mock_google_CallGAMCommand,
-    mock_ctx_forward,
-):
-    mock_google_user_exists.return_value = True
-    mock_google_user_is_deactivated.return_value = True
-
-    result = cli_runner.invoke(
-        reactivate, ["--force", "--recovery-email=foo@bar.com", "--recovery-phone=555-555-5555", "username"]
-    )
+def test_reactivate__recovery_info(mocker, cli_runner, mock_ctx_forward, mock_GoogleAccount, mock_GoogleUsers):
+    args = ["--force", "--recovery-email=foo@bar.com", "--recovery-phone=555-555-5555", "username"]
+    result = cli_runner.invoke(reactivate, args)
 
     assert result.exit_code == Result.SUCCESS
-    assert not result.exception
-    mock_google_CallGAMCommand.assert_has_calls(
-        [
-            call(("update", "user", "username@compiler.la", "recoveryemail", "foo@bar.com")),
-            call(("update", "user", "username@compiler.la", "recoveryphone", "555-555-5555")),
-        ]
+    mock_GoogleUsers.reset_recovery_info.assert_called_once_with(
+        account=mock_GoogleAccount, recovery_email="foo@bar.com", recovery_phone="555-555-5555"
     )
-    mock_ctx_forward.assert_has_calls([call(reset), call(backupcodes)])
+    mock_ctx_forward.assert_has_calls([mocker.call(reset), mocker.call(backupcodes)])

--- a/tests/commands/user/test_reset.py
+++ b/tests/commands/user/test_reset.py
@@ -2,7 +2,13 @@ import pytest
 
 from compiler_admin import Result
 from compiler_admin.commands.user.reset import __name__ as MODULE, reset
-from compiler_admin.services.google import USER_HELLO
+from compiler_admin.commands.user.signout import signout
+
+
+@pytest.fixture
+def mock_ctx_forward(mocker):
+    """Mock click.Context.forward."""
+    return mocker.patch("click.Context.forward")
 
 
 @pytest.fixture
@@ -16,72 +22,62 @@ def mock_input_no(mock_input_no):
 
 
 @pytest.fixture
-def mock_commands_signout(mock_commands_signout):
-    return mock_commands_signout(MODULE)
+def mock_GoogleAccount(mocker):
+    return mocker.patch(f"{MODULE}.GoogleAccount").return_value
 
 
 @pytest.fixture
-def mock_google_user_exists(mock_google_user_exists):
-    return mock_google_user_exists(MODULE)
+def mock_GoogleUsers(mocker):
+    return mocker.patch(f"{MODULE}.GoogleUsers").return_value
 
 
-@pytest.fixture
-def mock_google_CallGAMCommand(mock_google_CallGAMCommand):
-    return mock_google_CallGAMCommand(MODULE)
-
-
-def test_reset_user_does_not_exist(cli_runner, mock_google_user_exists):
-    mock_google_user_exists.return_value = False
+def test_reset__user_does_not_exist(cli_runner, mock_account_exists, mock_GoogleAccount):
+    mock_account_exists(mock_GoogleAccount, False)
 
     result = cli_runner.invoke(reset, ["username"])
 
     assert result.exit_code != Result.SUCCESS
+    assert "User does not exist" in result.output
 
 
 @pytest.mark.usefixtures("mock_input_yes")
-def test_reset_confirm_yes(cli_runner, mock_google_user_exists, mock_google_CallGAMCommand, mock_commands_signout):
-    mock_google_user_exists.return_value = True
+def test_reset__confirm_yes(cli_runner, mocker, mock_account_exists, mock_ctx_forward, mock_GoogleAccount, mock_GoogleUsers):
+    mock_account_exists(mock_GoogleAccount, True)
 
     result = cli_runner.invoke(reset, ["username"])
 
     assert result.exit_code == Result.SUCCESS
-    mock_google_CallGAMCommand.assert_called_once()
-    mock_commands_signout.callback.assert_called_once()
+    mock_GoogleUsers.reset_password.assert_called_once_with(account=mock_GoogleAccount, notify=None)
+    assert mocker.call(signout) in mock_ctx_forward.mock_calls
 
 
 @pytest.mark.usefixtures("mock_input_no")
-def test_reset_confirm_no(cli_runner, mock_google_user_exists, mock_google_CallGAMCommand, mock_commands_signout):
-    mock_google_user_exists.return_value = True
+def test_reset__confirm_no(cli_runner, mocker, mock_account_exists, mock_ctx_forward, mock_GoogleAccount, mock_GoogleUsers):
+    mock_account_exists(mock_GoogleAccount, True)
 
     result = cli_runner.invoke(reset, ["username"])
 
     assert result.exit_code == Result.SUCCESS
-    mock_google_CallGAMCommand.assert_not_called()
-    mock_commands_signout.callback.assert_not_called()
+    mock_GoogleUsers.reset_password.assert_not_called()
+    assert mocker.call(signout) not in mock_ctx_forward.mock_calls
 
 
-def test_reset_user_exists(cli_runner, mock_google_user_exists, mock_google_CallGAMCommand, mock_commands_signout):
-    mock_google_user_exists.return_value = True
+def test_reset__force(cli_runner, mocker, mock_account_exists, mock_ctx_forward, mock_GoogleAccount, mock_GoogleUsers):
+    mock_account_exists(mock_GoogleAccount, True)
 
     result = cli_runner.invoke(reset, ["--force", "username"])
 
     assert result.exit_code == Result.SUCCESS
-    mock_google_CallGAMCommand.assert_called_once()
-    call_args = " ".join(mock_google_CallGAMCommand.call_args[0][0])
-    assert "update user" in call_args
-    assert "password random changepassword" in call_args
-    mock_commands_signout.callback.assert_called_once()
+    mock_GoogleUsers.reset_password.assert_called_once_with(account=mock_GoogleAccount, notify=None)
+    assert mocker.call(signout) in mock_ctx_forward.mock_calls
 
 
-def test_reset_notify(cli_runner, mock_google_user_exists, mock_google_CallGAMCommand, mock_commands_signout):
-    mock_google_user_exists.return_value = True
+@pytest.mark.usefixtures("mock_input_yes")
+def test_reset__notify(cli_runner, mocker, mock_account_exists, mock_ctx_forward, mock_GoogleAccount, mock_GoogleUsers):
+    mock_account_exists(mock_GoogleAccount, True)
 
-    result = cli_runner.invoke(reset, ["--force", "--notify", "notification@example.com", "username"])
+    result = cli_runner.invoke(reset, ["--notify", "notification@example.com", "username"])
 
     assert result.exit_code == Result.SUCCESS
-    mock_google_CallGAMCommand.assert_called_once()
-    call_args = " ".join(mock_google_CallGAMCommand.call_args[0][0])
-    assert "update user" in call_args
-    assert "password random changepassword" in call_args
-    assert f"notify notification@example.com from {USER_HELLO}" in call_args
-    mock_commands_signout.callback.assert_called_once()
+    mock_GoogleUsers.reset_password.assert_called_once_with(account=mock_GoogleAccount, notify="notification@example.com")
+    assert mocker.call(signout) in mock_ctx_forward.mock_calls

--- a/tests/commands/user/test_restore.py
+++ b/tests/commands/user/test_restore.py
@@ -5,28 +5,36 @@ from compiler_admin.commands.user.restore import __name__ as MODULE, restore
 
 
 @pytest.fixture
+def mock_GoogleAccount(mocker):
+    return mocker.patch(f"{MODULE}.GoogleAccount").return_value
+
+
+@pytest.fixture
+def mock_GoogleArchive(mocker):
+    return mocker.patch(f"{MODULE}.GoogleArchive").return_value
+
+
+@pytest.fixture
 def mock_Path_exists(mocker):
     return mocker.patch(f"{MODULE}.pathlib.Path.exists")
 
 
-@pytest.fixture
-def mock_google_CallGYBCommand(mock_google_CallGYBCommand):
-    return mock_google_CallGYBCommand(MODULE)
-
-
-def test_restore_backup_exists(cli_runner, mock_Path_exists, mock_google_CallGYBCommand):
+def test_restore__backup_exists(cli_runner, mock_GoogleAccount, mock_GoogleArchive, mock_Path_exists):
     mock_Path_exists.return_value = True
 
     result = cli_runner.invoke(restore, ["username"])
 
     assert result.exit_code == Result.SUCCESS
-    mock_google_CallGYBCommand.assert_called_once()
+    mock_GoogleArchive.restore_email_backup.assert_called_once_with(
+        account=mock_GoogleAccount, backup_dir=f"GYB-GMail-Backup-{mock_GoogleAccount}"
+    )
 
 
-def test_restore_backup_does_not_exist(cli_runner, mock_Path_exists, mock_google_CallGYBCommand):
+def test_restore__backup_does_not_exist(cli_runner, mock_GoogleArchive, mock_Path_exists):
     mock_Path_exists.return_value = False
 
     result = cli_runner.invoke(restore, ["username"])
 
     assert result.exit_code != Result.SUCCESS
-    assert mock_google_CallGYBCommand.call_count == 0
+    assert "Couldn't find a local backup" in result.output
+    mock_GoogleArchive.restore_email_backup.assert_not_called

--- a/tests/commands/user/test_signout.py
+++ b/tests/commands/user/test_signout.py
@@ -15,41 +15,49 @@ def mock_input_no(mock_input_no):
 
 
 @pytest.fixture
-def mock_google_user_exists(mock_google_user_exists):
-    return mock_google_user_exists(MODULE)
+def mock_GoogleAccount(mocker):
+    return mocker.patch(f"{MODULE}.GoogleAccount").return_value
 
 
 @pytest.fixture
-def mock_google_CallGAMCommand(mock_google_CallGAMCommand):
-    return mock_google_CallGAMCommand(MODULE)
+def mock_GoogleUsers(mocker):
+    return mocker.patch(f"{MODULE}.GoogleUsers").return_value
 
 
 @pytest.mark.usefixtures("mock_input_yes")
-def test_signout_confirm_yes(cli_runner, mock_google_user_exists, mock_google_CallGAMCommand):
-    mock_google_user_exists.return_value = True
+def test_signout__confirm_yes(cli_runner, mock_account_exists, mock_GoogleAccount, mock_GoogleUsers):
+    mock_account_exists(mock_GoogleAccount, True)
 
     result = cli_runner.invoke(signout, ["username"])
 
     assert result.exit_code == Result.SUCCESS
-    mock_google_CallGAMCommand.assert_called_once()
-    call_args = mock_google_CallGAMCommand.call_args.args[0]
-    assert "user" in call_args and "signout" in call_args
+    mock_GoogleUsers.signout.assert_called_once_with(mock_GoogleAccount)
 
 
 @pytest.mark.usefixtures("mock_input_no")
-def test_signout_confirm_no(cli_runner, mock_google_user_exists, mock_google_CallGAMCommand):
-    mock_google_user_exists.return_value = True
+def test_signout__confirm_no(cli_runner, mock_account_exists, mock_GoogleAccount, mock_GoogleUsers):
+    mock_account_exists(mock_GoogleAccount, True)
 
     result = cli_runner.invoke(signout, ["username"])
 
     assert result.exit_code == Result.SUCCESS
-    mock_google_CallGAMCommand.assert_not_called()
+    mock_GoogleUsers.signout.assert_not_called()
 
 
-def test_signout_user_does_not_exist(cli_runner, mock_google_user_exists, mock_google_CallGAMCommand):
-    mock_google_user_exists.return_value = False
+def test_signout__force(cli_runner, mock_account_exists, mock_GoogleAccount, mock_GoogleUsers):
+    mock_account_exists(mock_GoogleAccount, True)
+
+    result = cli_runner.invoke(signout, ["--force", "username"])
+
+    assert result.exit_code == Result.SUCCESS
+    mock_GoogleUsers.signout.assert_called_once_with(mock_GoogleAccount)
+
+
+def test_signout__user_does_not_exist(cli_runner, mock_account_exists, mock_GoogleAccount, mock_GoogleUsers):
+    mock_account_exists(mock_GoogleAccount, False)
 
     result = cli_runner.invoke(signout, ["username"])
 
     assert result.exit_code != Result.SUCCESS
-    mock_google_CallGAMCommand.assert_not_called()
+    assert "User does not exist" in result.output
+    mock_GoogleUsers.signout.assert_not_called()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from click.testing import CliRunner
 from pytest_socket import disable_socket
 
 from compiler_admin import Result
+from compiler_admin.services.google import GoogleAccount, GoogleService
 
 
 def pytest_runtest_setup():
@@ -118,78 +119,6 @@ def mock_google_CallGYBCommand(mock_module_name):
 
 
 @pytest.fixture
-def mock_google_add_user_to_group(mock_module_name):
-    """Fixture returns a function that patches the add_user_to_group function from a given module."""
-    return mock_module_name("add_user_to_group")
-
-
-@pytest.fixture
-def mock_google_move_user_ou(mock_module_name):
-    """Fixture returns a function that patches the move_user_ou function from a given module."""
-    return mock_module_name("move_user_ou")
-
-
-@pytest.fixture
-def mock_google_remove_user_from_group(mock_module_name):
-    """Fixture returns a function that patches the remove_user_from_group function from a given module."""
-    return mock_module_name("remove_user_from_group")
-
-
-@pytest.fixture
-def mock_google_user_exists(mock_module_name):
-    """Fixture returns a function that patches the user_exists function from a given module."""
-    return mock_module_name("user_exists")
-
-
-@pytest.fixture
-def mock_google_user_exists_no(mock_google_user_exists):
-    """Fixture returns a function that patches the user_exists function from a given module to return False."""
-
-    def _mock_google_user_exists_no(module):
-        exists = mock_google_user_exists(module)
-        exists.return_value = False
-        return exists
-
-    return _mock_google_user_exists_no
-
-
-@pytest.fixture
-def mock_google_user_exists_yes(mock_google_user_exists):
-    """Fixture returns a function that patches the user_exists function from a given module to return True."""
-
-    def _mock_google_user_exists_yes(module):
-        exists = mock_google_user_exists(module)
-        exists.return_value = True
-        return exists
-
-    return _mock_google_user_exists_yes
-
-
-@pytest.fixture
-def mock_google_user_info(mock_module_name):
-    """Fixture returns a function that patches the user_info function from a given module."""
-    return mock_module_name("user_info")
-
-
-@pytest.fixture
-def mock_google_user_in_group(mock_module_name):
-    """Fixture returns a function that patches the user_in_group function from a given module."""
-    return mock_module_name("user_in_group")
-
-
-@pytest.fixture
-def mock_google_user_is_partner(mock_module_name):
-    """Fixture returns a function that patches the user_is_partner function from a given module."""
-    return mock_module_name("user_is_partner")
-
-
-@pytest.fixture
-def mock_google_user_is_staff(mock_module_name):
-    """Fixture returns a function that patches the user_is_staff function from a given module."""
-    return mock_module_name("user_is_staff")
-
-
-@pytest.fixture
 def mock_NamedTemporaryFile_with_readlines(mocker):
     """Fixture returns a function that patches NamedTemporaryFile in a given module.
 
@@ -208,6 +137,29 @@ def mock_NamedTemporaryFile_with_readlines(mocker):
         return patched
 
     return _mock_NamedTemporaryFile
+
+
+@pytest.fixture
+def mock_account_exists(mocker):
+    """Returns a function that mocks the exists method on a GoogleAccounts instance."""
+
+    def _mock_account_exists(account: GoogleAccount, exists: bool = True) -> bool:
+        return mocker.patch.object(account, "exists", return_value=exists)
+
+    return _mock_account_exists
+
+
+@pytest.fixture
+def mock_gam_gyb(mocker):
+    """Returns a function that mocks the GAM and GYB commands on a GoogleService."""
+
+    def _mock_gam_gyb(service: GoogleService) -> GoogleService:
+        mocker.patch.object(service, "gam_command")
+        mocker.patch.object(service, "gam_command_output")
+        mocker.patch.object(service, "gyb_command")
+        return service
+
+    return _mock_gam_gyb
 
 
 @pytest.fixture

--- a/tests/services/test_google.py
+++ b/tests/services/test_google.py
@@ -1,3 +1,4 @@
+import json
 import re
 import sys
 from tempfile import TemporaryFile
@@ -6,41 +7,21 @@ import pytest
 
 from compiler_admin import Format, Result
 from compiler_admin.services.google import (
-    DOMAIN,
-    GAM,
-    GROUP_PARTNERS,
-    GROUP_STAFF,
-    GROUP_TEAM,
-    GYB,
-    ORG_UNITS,
-    OU_ALUMNI,
-    USER_ARCHIVE,
-    CallGAMCommand,
-    CallGYBCommand,
+    GoogleAccount,
+    GoogleArchive,
+    GoogleGroups,
+    GoogleOrgs,
+    GoogleService,
+    GoogleUsers,
     __name__ as MODULE,
-    add_user_to_group,
-    get_backup_codes,
-    get_groups,
-    get_org_units,
-    get_users,
-    move_user_ou,
-    remove_user_from_group,
-    user_account_name,
-    user_exists,
-    user_in_group,
-    user_in_ou,
-    user_info,
-    user_is_deactivated,
-    user_is_partner,
-    user_is_staff,
 )
 
 
 @pytest.fixture
 def get_command_str():
-    def _get_command_str(mocked_CallGAMCommand):
-        mocked_CallGAMCommand.assert_called_once()
-        call_args = mocked_CallGAMCommand.call_args[0]
+    def _get_command_str(mocked_gam_command):
+        mocked_gam_command.assert_called_once()
+        call_args = mocked_gam_command.call_args[0]
         return " ".join([str(arg) for arg in call_args[0]])
 
     return _get_command_str
@@ -48,37 +29,17 @@ def get_command_str():
 
 @pytest.fixture
 def mock_gam_CallGAMCommand(mocker):
-    return mocker.patch(f"{MODULE}.__CallGAMCommand")
+    return mocker.patch(f"{MODULE}.CallGAMCommand")
 
 
 @pytest.fixture
-def mock_google_CallGAMCommand(mock_google_CallGAMCommand):
-    return mock_google_CallGAMCommand(MODULE)
+def mock_GoogleGroups(mocker):
+    return mocker.patch(f"{MODULE}.GoogleGroups")
 
 
 @pytest.fixture
-def mock_google_user_exists_no(mock_google_user_exists_no):
-    return mock_google_user_exists_no(MODULE)
-
-
-@pytest.fixture
-def mock_google_user_exists_yes(mock_google_user_exists_yes):
-    return mock_google_user_exists_yes(MODULE)
-
-
-@pytest.fixture
-def mock_google_user_info(mock_google_user_info):
-    return mock_google_user_info(MODULE)
-
-
-@pytest.fixture
-def mock_google_user_in_group(mock_google_user_in_group):
-    return mock_google_user_in_group(MODULE)
-
-
-@pytest.fixture
-def mock_google_user_in_ou(mocker):
-    return mocker.patch(f"{MODULE}.user_in_ou")
+def mock_GoogleOrgs(mocker):
+    return mocker.patch(f"{MODULE}.GoogleOrgs")
 
 
 @pytest.fixture
@@ -86,422 +47,585 @@ def mock_subprocess_call(mocker):
     return mocker.patch(f"{MODULE}.subprocess.call")
 
 
-def test_user_account_name_None():
-    username = None
-    account = user_account_name(username)
+class TestGoogleService:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.google = GoogleService()
 
-    assert account is None
+    def test_gam_command__prepends_gam(self, mock_gam_CallGAMCommand, get_command_str):
+        self.google.gam_command(("args",))
 
+        command = get_command_str(mock_gam_CallGAMCommand)
 
-def test_user_account_name_not_in_domain():
-    username = "account"
-    account = user_account_name(username)
+        assert command == f"{self.google.GAM} args"
 
-    assert account == f"{username}@{DOMAIN}"
+    def test_gam_command__does_not_duplicate_gam(self, mock_gam_CallGAMCommand, get_command_str):
+        self.google.gam_command((self.google.GAM, "args"))
 
+        command = get_command_str(mock_gam_CallGAMCommand)
 
-def test_user_account_name_in_domain():
-    username = f"account@{DOMAIN}"
-    account = user_account_name(username)
+        assert command == f"{self.google.GAM} args"
 
-    assert username == account
+    def test_gam_command_output(self, mock_gam_CallGAMCommand, mock_NamedTemporaryFile_with_readlines, get_command_str):
+        expected_output = ["output"]
+        mock_NamedTemporaryFile_with_readlines(MODULE, expected_output)
 
+        output = self.google.gam_command_output(("command",))
 
-def test_user_not_in_domain(capfd):
-    username = "nope@anotherdomain.com"
-    res = user_exists(username)
-    captured = capfd.readouterr()
+        assert output == expected_output
 
-    assert res is False
-    assert "User not in domain" in captured.out
+    def test_gam_command__stdouterr_override(self, mock_gam_CallGAMCommand, get_command_str):
+        self.google.gam_command(("args",), stdout="override-stdout", stderr="override-stderr")
 
+        command = get_command_str(mock_gam_CallGAMCommand)
 
-def test_CallGAMCommand_prepends_gam(mock_gam_CallGAMCommand, get_command_str):
-    CallGAMCommand(("args",))
+        assert "redirect stdout override-stdout" in command
+        assert "redirect stderr override-stderr" in command
 
-    command = get_command_str(mock_gam_CallGAMCommand)
+    def test_gyb_command__prepends_gyb(self, mock_subprocess_call):
+        self.google.gyb_command(("args",))
 
-    assert command == f"{GAM} args"
+        mock_subprocess_call.assert_called_once()
+        call_args = mock_subprocess_call.call_args[0][0]
+        assert call_args == (self.google.GYB, "args")
 
+    def test_gyb_command__does_not_duplicate_gyb(self, mock_subprocess_call):
+        self.google.gyb_command((self.google.GYB, "args"))
 
-def test_CallGAMCommand_does_not_duplicate_gam(mock_gam_CallGAMCommand, get_command_str):
-    CallGAMCommand((GAM, "args"))
+        mock_subprocess_call.assert_called_once()
+        call_args = mock_subprocess_call.call_args[0][0]
+        assert call_args == (self.google.GYB, "args")
 
-    command = get_command_str(mock_gam_CallGAMCommand)
+    def test_gyb_command__stdouterr_default(self, mock_subprocess_call):
+        self.google.gyb_command(("args",))
 
-    assert command == f"{GAM} args"
+        mock_subprocess_call.assert_called_once()
+        call_kwargs = mock_subprocess_call.call_args.kwargs
 
+        assert "stdout" in call_kwargs
+        assert call_kwargs["stdout"] == sys.stdout
+        assert "stderr" in call_kwargs
+        assert call_kwargs["stderr"] == sys.stderr
 
-def test_CallGAMCommand_stdouterr_override(mock_gam_CallGAMCommand, get_command_str):
-    CallGAMCommand(("args",), stdout="override-stdout", stderr="override-stderr")
+    def test_gyb_command__stdouterr_override(self, mock_subprocess_call):
+        stdout, stderr = TemporaryFile(), TemporaryFile()
+        self.google.gyb_command(("args",), stdout=stdout, stderr=stderr)
 
-    command = get_command_str(mock_gam_CallGAMCommand)
+        mock_subprocess_call.assert_called_once()
+        call_kwargs = mock_subprocess_call.call_args.kwargs
 
-    assert "redirect stdout override-stdout" in command
-    assert "redirect stderr override-stderr" in command
+        assert "stdout" in call_kwargs
+        assert call_kwargs["stdout"] == stdout
+        assert "stderr" in call_kwargs
+        assert call_kwargs["stderr"] == stderr
 
+        stdout.close()
+        stderr.close()
 
-def test_CallGYBCommand_prepends_gyb(mock_subprocess_call):
-    CallGYBCommand(("args",))
 
-    mock_subprocess_call.assert_called_once()
-    call_args = mock_subprocess_call.call_args[0][0]
-    assert call_args == (GYB, "args")
+class TestGoogleAccount:
 
+    @pytest.fixture(autouse=True)
+    def setup(self, mock_gam_gyb):
+        self.google = GoogleAccount("username")
+        mock_gam_gyb(self.google)
 
-def test_CallGYBCommand_does_not_duplicate_gyb(mock_subprocess_call):
-    CallGYBCommand((GYB, "args"))
+    def test_init__username_None(self):
+        username = None
+        account = GoogleAccount(username)
 
-    mock_subprocess_call.assert_called_once()
-    call_args = mock_subprocess_call.call_args[0][0]
-    assert call_args == (GYB, "args")
+        assert account.username == account.account == ""
+        assert str(account) == ""
 
+    def test_init__username_not_in_domain(self):
+        username = "account"
+        account = GoogleAccount(username)
 
-def test_CallGYBCommand_stdouterr_default(mock_subprocess_call):
-    CallGYBCommand(("args",))
+        assert account == f"{username}@{GoogleAccount.DOMAIN}"
 
-    mock_subprocess_call.assert_called_once()
-    call_kwargs = mock_subprocess_call.call_args.kwargs
+    def test_init__username_in_domain(self):
+        username = f"account@{GoogleAccount.DOMAIN}"
+        account = GoogleAccount(username)
 
-    assert "stdout" in call_kwargs
-    assert call_kwargs["stdout"] == sys.stdout
-    assert "stderr" in call_kwargs
-    assert call_kwargs["stderr"] == sys.stderr
+        assert username == account
 
+    def test_add_email_alias(self, get_command_str):
+        alias = "alias@example.com"
 
-def test_CallGYBCommand_stdouterr_override(mock_subprocess_call):
-    stdout, stderr = TemporaryFile(), TemporaryFile()
-    CallGYBCommand(("args",), stdout=stdout, stderr=stderr)
+        self.google.add_email_alias(alias)
 
-    mock_subprocess_call.assert_called_once()
-    call_kwargs = mock_subprocess_call.call_args.kwargs
+        command = get_command_str(self.google.gam_command)
+        assert f"create alias {alias}" in command
+        assert f"user {self.google}" in command
 
-    assert "stdout" in call_kwargs
-    assert call_kwargs["stdout"] == stdout
-    assert "stderr" in call_kwargs
-    assert call_kwargs["stderr"] == stderr
+    def test_exists__exists(self, mocker):
+        mocker.patch.object(self.google, "get_info", return_value={"First Name": "Test", "Last Name": "User"})
 
-    stdout.close()
-    stderr.close()
+        assert self.google.exists() is True
 
+    def test_exists__not_exists(self, mocker):
+        mocker.patch.object(self.google, "get_info", return_value={})
 
-def test_add_user_to_group(mock_google_CallGAMCommand):
-    add_user_to_group("username", "thegroup")
+        assert self.google.exists() is False
 
-    mock_google_CallGAMCommand.assert_called_once()
+    def test_get_backup_codes__user_does_not_exist(self, mock_account_exists, capfd):
+        mock_account_exists(self.google, False)
 
+        res = self.google.get_backup_codes()
+        captured = capfd.readouterr()
 
-def test_get_backup_codes_user_does_not_exist(mock_google_user_exists_no, capfd):
-    username = "nonexistent"
-    res = get_backup_codes(username)
-    captured = capfd.readouterr()
+        assert res == ""
+        assert f"User does not exist: {self.google}" in captured.out
 
-    mock_google_user_exists_no.assert_called_once_with(username)
-    assert res == ""
-    assert f"User does not exist: {username}" in captured.out
+    def test_get_backup_codes__user_exists_has_codes(self, mock_account_exists):
+        codes = "12345678"
+        self.google.gam_command_output.return_value = codes
+        mock_account_exists(self.google, True)
 
+        res = self.google.get_backup_codes()
 
-@pytest.mark.usefixtures("mock_google_user_exists_yes")
-def test_get_backup_codes_user_exists_has_codes(
-    mock_gam_CallGAMCommand, mock_NamedTemporaryFile_with_readlines, get_command_str
-):
-    username = "existent"
-    codes = "12345678"
-    mock_NamedTemporaryFile_with_readlines(MODULE, [codes])
+        assert res == codes
 
-    res = get_backup_codes(username)
+    def test_get_backup_codes__user_exists_no_codes(self, mock_account_exists):
+        no_codes_output = "Show 0 Backup Verification Codes"
+        new_codes = "87654321"
+        self.google.gam_command_output.side_effect = [[no_codes_output], [new_codes]]
+        mock_account_exists(self.google, True)
 
-    command = get_command_str(mock_gam_CallGAMCommand)
+        assert self.google.get_backup_codes() == new_codes
 
-    assert "show" in command
-    assert res == codes
+    def test_get_info__exists(self, mock_NamedTemporaryFile_with_readlines):
+        mock_NamedTemporaryFile_with_readlines(MODULE, ["First Name:Test", "Last Name:User"])
+        self.google.gam_command.return_value = Result.SUCCESS
 
+        res = self.google.get_info()
 
-@pytest.mark.usefixtures("mock_google_user_exists_yes")
-def test_get_backup_codes_user_exists_no_codes(mocker, mock_gam_CallGAMCommand):
-    username = "existent"
-    no_codes_output = "Show 0 Backup Verification Codes"
-    new_codes = "87654321"
+        assert res == {"First Name": "Test", "Last Name": "User"}
 
-    mock_file_handler = mocker.MagicMock()
-    mock_file_handler.readlines.side_effect = [[no_codes_output], [new_codes]]
-    mock_file_handler.name = "tempfile"
+    def test_get_info__not_exists(self):
+        self.google.gam_command.return_value = Result.FAILURE
 
-    mock_temp_file_context = mocker.MagicMock()
-    mock_temp_file_context.__enter__.return_value = mock_file_handler
-    mock_temp_file_context.__exit__.return_value = None
+        res = self.google.get_info()
 
-    mocker.patch(f"{MODULE}.NamedTemporaryFile", return_value=mock_temp_file_context)
+        assert res == {}
 
-    res = get_backup_codes(username)
+    def test_is_deactivated__checks_alumni_ou(self, mock_GoogleOrgs):
+        self.google.is_deactivated()
 
-    assert mock_gam_CallGAMCommand.call_count == 2
-    assert "show" in mock_gam_CallGAMCommand.call_args_list[0].args[0]
-    assert "update" in mock_gam_CallGAMCommand.call_args_list[1].args[0]
-    assert res == new_codes
+        mock_GoogleOrgs.assert_called_once_with(mock_GoogleOrgs.OU_ALUMNI)
+        mock_GoogleOrgs.return_value.contains_user.assert_called_once_with(self.google)
 
+    def test_is_partner__checks_partner_group(self, mock_GoogleGroups):
+        self.google.is_partner()
 
-def test_get_groups(mock_google_CallGAMCommand, get_command_str):
-    get_groups()
+        mock_GoogleGroups.assert_called_once_with(mock_GoogleGroups.GROUP_PARTNERS)
+        mock_GoogleGroups.return_value.contains_user.assert_called_once_with(self.google)
 
-    command = get_command_str(mock_google_CallGAMCommand)
+    def test_is_staff__checks_staff_group(self, mock_GoogleGroups):
+        self.google.is_staff()
 
-    assert "print groups" in command
+        mock_GoogleGroups.assert_called_once_with(mock_GoogleGroups.GROUP_STAFF)
+        mock_GoogleGroups.return_value.contains_user.assert_called_once_with(self.google)
 
 
-def test_get_groups__format_csv(mock_google_CallGAMCommand, get_command_str):
-    get_groups(format=Format.CSV)
+class TestGoogleArchive:
+    @pytest.fixture(autouse=True)
+    def setup(self, mock_gam_gyb):
+        self.account = GoogleAccount("username")
+        self.google = GoogleArchive()
+        mock_gam_gyb(self.google)
 
-    command = get_command_str(mock_google_CallGAMCommand)
+    def test_archive_content(self, get_command_str):
+        self.google.archive_content(self.account)
 
-    assert "allfields" in command
+        command = get_command_str(self.google.gam_command)
+        assert f"create transfer {self.account}" in command
+        assert "calendar,drive" in command
+        assert str(GoogleUsers.USER_ARCHIVE) in command
+        assert "releaseresources" in command
 
+    def test_await_archive_completion(self, mocker):
+        self.google.gam_command_output.side_effect = [["Overall Transfer Status: completed"]]
 
-def test_get_groups__format_json(mock_google_CallGAMCommand, get_command_str):
-    get_groups(format=Format.JSON)
+        self.google.await_archive_completion(self.account)
 
-    command = get_command_str(mock_google_CallGAMCommand)
+        assert self.google.gam_command_output.call_count == 1
 
-    assert "allfields" in command
-    assert "members managers owners" in command
-    assert "formatjson" in command
+    def test_await_archive_completion__callback(self, mocker):
+        callback = mocker.Mock()
+        self.google.gam_command_output.side_effect = [
+            ["Overall Transfer Status: pending"],
+            ["Overall Transfer Status: completed"],
+        ]
 
+        self.google.await_archive_completion(self.account, callback=callback)
 
-def test_get_org_units(mock_google_CallGAMCommand, get_command_str):
-    get_org_units(kwarg1="one")
+        assert self.google.gam_command_output.call_count == 2
+        assert mocker.call("", "Overall Transfer Status: pending") in callback.mock_calls
+        assert mocker.call("Overall Transfer Status: pending", "Overall Transfer Status: completed") in callback.mock_calls
 
-    command = get_command_str(mock_google_CallGAMCommand)
+    def test_create_email_backup(self, get_command_str):
+        self.google.create_email_backup(self.account)
 
-    assert "print orgs" in command
-    assert "kwarg1 one" in command
+        command = get_command_str(self.google.gyb_command)
+        assert "--service-account" in command
+        assert f"--email {self.account}" in command
+        assert "--action backup" in command
 
+    def test_restore_email_backup(self, get_command_str):
+        self.google.restore_email_backup(self.account, "/backupdir")
 
-def test_get_users(mock_google_CallGAMCommand, get_command_str):
-    get_users(kwarg1="one")
+        command = get_command_str(self.google.gyb_command)
+        assert "--service-account" in command
+        assert f"--email {GoogleUsers.USER_ARCHIVE}" in command
+        assert "--action restore" in command
+        assert "--local-folder /backupdir" in command
+        assert f"--label-restored {self.account}" in command
 
-    command = get_command_str(mock_google_CallGAMCommand)
 
-    assert "print users" in command
-    assert "issuspended false isarchived false" in command
-    assert "kwarg1 one" in command
+class TestGoogleGroups:
+    @pytest.fixture(autouse=True)
+    def setup(self, mock_gam_gyb):
+        self.account = GoogleAccount("username")
+        self.group = GoogleAccount("group")
+        self.google = GoogleGroups(self.group)
+        mock_gam_gyb(self.google)
 
+    def test_add_user(self, get_command_str):
+        self.google.add_user(self.account)
 
-def test_get_users__inactive(mock_google_CallGAMCommand, get_command_str):
-    get_users(inactive=True)
+        command = get_command_str(self.google.gam_command)
 
-    command = get_command_str(mock_google_CallGAMCommand)
+        assert f"user {self.account}" in command
+        assert f"add groups member {self.group}" in command
 
-    assert "issuspended true isarchived true" in command
+    def test_contains_user__user_does_not_exist(self, mock_account_exists):
+        mock_account_exists(self.account, False)
 
+        assert self.google.contains_user(self.account) is False
 
-def test_get_users__format_csv(mock_google_CallGAMCommand, get_command_str):
-    get_users(format=Format.CSV)
+    def test_contains_user__user_exists_in_group(self, mock_account_exists):
+        mock_account_exists(self.account, True)
+        self.google.gam_command_output.return_value = [str(self.group)]
 
-    command = get_command_str(mock_google_CallGAMCommand)
+        assert self.google.contains_user(self.account) is True
 
-    assert "full" in command
+    def test_contains_user__user_exists_not_in_group(self, mock_account_exists):
+        mock_account_exists(self.account, True)
+        self.google.gam_command_output.return_value = [str(self.group)]
 
+        assert self.google.contains_user(self.account, group=GoogleAccount("nope")) is False
 
-@pytest.mark.parametrize("inactive,expected_in_command", ((True, "users_arch_or_susp"), (False, "users_na_ns")))
-def test_get_users__format_json(mock_google_CallGAMCommand, get_command_str, inactive, expected_in_command):
-    get_users(inactive=inactive, format=Format.JSON)
+    def test_get(self, get_command_str):
+        self.google.get()
 
-    command = get_command_str(mock_google_CallGAMCommand)
+        command = get_command_str(self.google.gam_command_output)
 
-    assert "info users all" in command
-    assert "formatjson" in command
-    assert expected_in_command in command
+        assert "print groups" in command
 
+    def test_get__kwargs(self, get_command_str):
+        self.google.get(kwarg1="value1")
 
-def test_get_users__org_units(mock_google_CallGAMCommand, get_command_str):
-    get_users(org_units=ORG_UNITS.values())
+        command = get_command_str(self.google.gam_command_output)
 
-    command = get_command_str(mock_google_CallGAMCommand)
+        assert "kwarg1 value1" in command
 
-    assert "queries" in command
-    for ou in ORG_UNITS.values():
-        assert f"'orgUnitPath={ou}'" in command
+    def test_get__format_csv(self, get_command_str):
+        self.google.get(format=Format.CSV)
 
+        command = get_command_str(self.google.gam_command_output)
 
-def test_get_users__org_units_unexepected():
-    with pytest.raises(ValueError, match=re.escape("Unexpected org_unit(s): /unexpected")):
-        get_users(org_units=["/unexpected"])
+        assert "allfields" in command
 
+    def test_get__format_json(self, get_command_str):
+        expected = json.dumps(
+            [
+                {
+                    "json": "json_value",
+                    "members": [{"json-members": "json_members_value"}],
+                    "json-settings": "json_settings_value",
+                }
+            ]
+        )
 
-@pytest.mark.parametrize("inactive,ou_entity", [(True, "ous_arch"), (False, "ou_na_ns")])
-def test_get_users__org_units__format_json(mock_google_CallGAMCommand, get_command_str, inactive, ou_entity):
-    get_users(inactive=inactive, org_units=ORG_UNITS.values(), format=Format.JSON)
+        self.google.gam_command_output.return_value = [
+            "# comment, blank line, should be skipped",
+            "email,JSON,JSON-members,JSON-settings",
+            'example@example.com,"{""json"":""json_value""}","[{""json-members"":""json_members_value""}]","{""json-settings"":""json_settings_value""}",',  # noqa: E501
+        ]
 
-    command = get_command_str(mock_google_CallGAMCommand)
+        output = self.google.get(format=Format.JSON)
+        command = get_command_str(self.google.gam_command_output)
 
-    assert ou_entity in command
+        assert "allfields" in command
+        assert "members managers owners" in command
+        assert "formatjson" in command
+        assert output == expected
 
+    def test_get__format_json__bad_encoding(self):
+        self.google.gam_command_output.return_value = [
+            "email,JSON,JSON-members,JSON-settings",
+            "example@example.com,not-json,not-json,not-json",
+        ]
 
-def test_move_user_ou(mock_google_CallGAMCommand):
-    move_user_ou("username", "theou")
+        output = self.google.get(format=Format.JSON)
 
-    mock_google_CallGAMCommand.assert_called_once()
+        assert output == "[]"
 
+    def test_get__format_json__missing_data(self):
+        self.google.gam_command_output.return_value = [
+            "email,JSON,JSON-members,JSON-settings",
+            "example@example.com,,,",
+        ]
 
-def test_remove_user_from_group(mock_google_CallGAMCommand):
-    remove_user_from_group("username", "thegroup")
+        output = self.google.get(format=Format.JSON)
 
-    mock_google_CallGAMCommand.assert_called_once()
+        assert output == "[]"
 
+    def test_get__format_json__no_data(self):
+        self.google.gam_command_output.return_value = []
 
-def test_user_exists_username_not_in_domain(capfd):
-    res = user_exists("someone@domain.com")
-    captured = capfd.readouterr()
+        output = self.google.get(format=Format.JSON)
 
-    assert res is False
-    assert "User not in domain" in captured.out
+        assert output == "[]"
 
+    def test_remove_user(self, get_command_str):
+        self.google.remove_user(self.account)
 
-def test_user_exists_user_exists(mock_google_user_info):
-    mock_google_user_info.return_value = {"First Name": "Test", "Last Name": "User"}
+        command = get_command_str(self.google.gam_command)
 
-    res = user_exists(user_account_name("username"))
+        assert f"update group {self.group}" in command
+        assert f"delete {self.account}" in command
 
-    assert res is True
 
+class TestGoogleOrgs:
+    @pytest.fixture(autouse=True)
+    def setup(self, mock_gam_gyb):
+        self.account = GoogleAccount("username")
+        self.ou = GoogleOrgs.OU_SERVICE_ACCOUNTS
+        self.google = GoogleOrgs(self.ou)
+        mock_gam_gyb(self.google)
 
-def test_user_exists_user_does_not_exist(mock_google_user_info):
-    mock_google_user_info.return_value = {}
+    @pytest.mark.parametrize("ou_key", GoogleOrgs.ORG_UNITS.keys())
+    def test_get_item(self, ou_key):
+        assert self.google[ou_key] == self.google.ORG_UNITS[ou_key]
 
-    res = user_exists(user_account_name("username"))
+    def test_contains_user__unexepected_ou(self):
+        with pytest.raises(ValueError, match="Unexpected OU: /unexpected"):
+            self.google.contains_user(self.account, "/unexpected")
 
-    assert res is False
+    def test_contains_user__user_does_not_exist(self, mock_account_exists):
+        mock_account_exists(self.account, False)
 
+        assert self.google.contains_user(self.account, self.ou) is False
 
-def test_user_info_user_exists(mock_gam_CallGAMCommand, mock_NamedTemporaryFile_with_readlines):
-    mock_NamedTemporaryFile_with_readlines(MODULE, ["First Name:Test", "Last Name:User"])
-    mock_gam_CallGAMCommand.return_value = Result.SUCCESS
+    def test_contains_user__user_exists_in_ou(self, mock_account_exists):
+        mock_account_exists(self.account, True)
+        self.google.gam_command_output.return_value = [str(self.account)]
 
-    res = user_info(user_account_name("username"))
+        assert self.google.contains_user(self.account, self.ou) is True
 
-    assert res == {"First Name": "Test", "Last Name": "User"}
+    def test_contains_user__user_exists_not_in_ou(self, mock_account_exists):
+        mock_account_exists(self.account, True)
+        self.google.gam_command_output.return_value = ["nope"]
 
+        assert self.google.contains_user(self.account, self.ou) is False
 
-def test_user_info_user_does_not_exists(mock_gam_CallGAMCommand):
-    mock_gam_CallGAMCommand.return_value = Result.FAILURE
+    def test_get(self, get_command_str):
+        self.google.get()
 
-    res = user_info(user_account_name("username"))
+        command = get_command_str(self.google.gam_command_output)
 
-    assert res == {}
+        assert "print orgs" in command
 
+    def test_get__kwargs(self, get_command_str):
+        self.google.get(kwarg1="value1")
 
-@pytest.mark.usefixtures("mock_google_user_exists_no")
-def test_user_in_group_user_does_not_exist(capfd):
-    res = user_in_group("username", "group")
-    captured = capfd.readouterr()
+        command = get_command_str(self.google.gam_command_output)
 
-    assert res is False
-    assert "User does not exist" in captured.out
+        assert "kwarg1 value1" in command
 
+    def test_move_user(self):
+        self.google.move_user(self.account, self.ou)
 
-@pytest.mark.usefixtures("mock_google_CallGAMCommand", "mock_google_user_exists_yes")
-def test_user_in_group_user_exists_in_group(mock_NamedTemporaryFile_with_readlines):
-    mock_NamedTemporaryFile_with_readlines(MODULE, ["group"])
+        self.google.gam_command.assert_called_once()
 
-    res = user_in_group("username", "group")
+    def test_move_user__unexpected_ou(self):
+        with pytest.raises(ValueError, match="Unexpected OU: /unexpected"):
+            self.google.move_user(self.account, "/unexpected")
 
-    assert res is True
 
+class TestGoogleUsers:
+    @pytest.fixture(autouse=True)
+    def setup(self, mock_gam_gyb):
+        self.account = GoogleAccount("username")
+        self.google = GoogleUsers()
+        mock_gam_gyb(self.google)
 
-@pytest.mark.usefixtures("mock_google_CallGAMCommand", "mock_google_user_exists_yes")
-def test_user_in_group_user_exists_not_in_group(mock_NamedTemporaryFile_with_readlines):
-    mock_NamedTemporaryFile_with_readlines(MODULE, ["group"])
+    def test_clear_profile(self, mocker):
+        self.google.clear_profile(self.account)
 
-    res = user_in_group("username", "nope")
+        for prop in ["address", "location", "otheremail", "phone"]:
+            assert mocker.call(("update", "user", self.account, prop, "clear")) in self.google.gam_command.mock_calls
 
-    assert res is False
+    def test_create(self, get_command_str):
+        self.google.create(self.account)
 
+        command = get_command_str(self.google.gam_command)
+        assert f"create user {self.account}" in command
+        assert "password random" in command
+        assert "changepassword" in command
 
-@pytest.mark.usefixtures("mock_google_user_exists_no")
-def test_user_in_ou_user_does_not_exist(capfd):
-    res = user_in_ou("username", "ou")
-    captured = capfd.readouterr()
+    def test_create__notify(self, get_command_str):
+        self.google.create(self.account, notify="notify@example.com")
 
-    assert res is False
-    assert "User does not exist" in captured.out
+        command = get_command_str(self.google.gam_command)
+        assert "notify notify@example.com" in command
+        assert f"from {GoogleUsers.USER_HELLO}" in command
 
+    def test_delete(self, get_command_str):
+        self.google.delete(self.account)
 
-@pytest.mark.usefixtures("mock_google_user_exists_yes")
-def test_user_in_ou_user_exists_in_ou(mock_NamedTemporaryFile_with_readlines):
-    mock_NamedTemporaryFile_with_readlines(MODULE, ["username"])
+        command = get_command_str(self.google.gam_command)
+        assert f"delete user {self.account}" in command
+        assert "noactionifalias" in command
 
-    res = user_in_ou("username", "ou")
+    def test_deprovision_popimap(self, get_command_str):
+        self.google.deprovision_popimap(self.account)
 
-    assert res is True
+        command = get_command_str(self.google.gam_command)
+        assert f"user {self.account}" in command
+        assert "deprovision popimap" in command
 
+    def test_disable_2fa(self, get_command_str):
+        self.google.disable_2fa(self.account)
 
-@pytest.mark.usefixtures("mock_google_user_exists_yes")
-def test_user_in_ou_user_exists_not_in_ou(mock_NamedTemporaryFile_with_readlines):
-    mock_NamedTemporaryFile_with_readlines(MODULE, ["nope"])
+        command = get_command_str(self.google.gam_command)
+        assert f"user {self.account}" in command
+        assert "turnoff2sv" in command
 
-    res = user_in_ou("username", "ou")
+    def test_get(self, get_command_str):
+        self.google.get(kwarg1="one")
 
-    assert res is False
+        command = get_command_str(self.google.gam_command_output)
 
+        assert "print users" in command
+        assert "issuspended false isarchived false" in command
+        assert "kwarg1 one" in command
 
-def test_user_is_deactivated_checks_alumni_ou(mock_google_user_in_ou):
-    user_is_deactivated("username")
+    def test_get__inactive(self, get_command_str):
+        self.google.get(inactive=True)
 
-    mock_google_user_in_ou.assert_called_once()
-    assert mock_google_user_in_ou.call_args.args == ("username", OU_ALUMNI)
+        command = get_command_str(self.google.gam_command_output)
 
+        assert "issuspended true isarchived true" in command
 
-def test_user_is_partner_checks_partner_group(mock_google_user_in_group):
-    user_is_partner("username")
+    def test_get__format_csv(self, get_command_str):
+        self.google.get(format=Format.CSV)
 
-    mock_google_user_in_group.assert_called_once()
-    assert mock_google_user_in_group.call_args.args == ("username", GROUP_PARTNERS)
+        command = get_command_str(self.google.gam_command_output)
 
+        assert "full" in command
 
-def test_user_is_staff_checks_staff_group(mock_google_user_in_group):
-    user_is_staff("username")
+    @pytest.mark.parametrize("inactive,expected_in_command", ((True, "users_arch_or_susp"), (False, "users_na_ns")))
+    def test_get__format_json(self, get_command_str, inactive, expected_in_command):
+        self.google.get(inactive=inactive, format=Format.JSON)
 
-    mock_google_user_in_group.assert_called_once()
-    assert mock_google_user_in_group.call_args.args == ("username", GROUP_STAFF)
+        command = get_command_str(self.google.gam_command_output)
+
+        assert "info users all" in command
+        assert "formatjson" in command
+        assert expected_in_command in command
+
+    def test_get__org_units(self, get_command_str):
+        self.google.get(org_units=GoogleOrgs.ORG_UNITS.values())
+
+        command = get_command_str(self.google.gam_command_output)
+
+        assert "queries" in command
+        for ou in GoogleOrgs.ORG_UNITS.values():
+            assert f"'orgUnitPath={ou}'" in command
+
+    def test_get__org_units_unexepected(self):
+        with pytest.raises(ValueError, match=re.escape("Unexpected org_unit(s): /unexpected")):
+            self.google.get(org_units=["/unexpected"])
+
+    @pytest.mark.parametrize("inactive,ou_entity", [(True, "ous_arch"), (False, "ou_na_ns")])
+    def test_get__org_units__format_json(self, get_command_str, inactive, ou_entity):
+        self.google.get(inactive=inactive, org_units=GoogleOrgs.ORG_UNITS.values(), format=Format.JSON)
+
+        command = get_command_str(self.google.gam_command_output)
+
+        assert ou_entity in command
+
+    def test_reset_recovery_info(self, mocker):
+        self.google.reset_recovery_info(self.account, recovery_email="email@example.com", recovery_phone="555-555-5555")
+
+        assert (
+            mocker.call(("update", "user", self.account, "recoveryemail", "email@example.com"))
+            in self.google.gam_command.mock_calls
+        )
+        assert (
+            mocker.call(("update", "user", self.account, "recoveryphone", "555-555-5555"))
+            in self.google.gam_command.mock_calls
+        )
+
+    def test_reset_password(self, get_command_str):
+        self.google.reset_password(self.account)
+
+        command = get_command_str(self.google.gam_command)
+        assert f"update user {self.account} password random" in command
+        assert "changepassword" in command
+
+    def test_reset_password__notify(self, get_command_str):
+        self.google.reset_password(self.account, notify="notify@example.com")
+
+        command = get_command_str(self.google.gam_command)
+        assert f"notify notify@example.com from {GoogleUsers.USER_HELLO}" in command
+
+    def test_remove_from_groups(self, get_command_str):
+        self.google.remove_from_groups(self.account)
+
+        command = get_command_str(self.google.gam_command)
+        assert f"user {self.account}" in command
+        assert "delete groups" in command
+
+    def test_signout(self, get_command_str):
+        self.google.signout(self.account)
+
+        command = get_command_str(self.google.gam_command)
+        assert f"user {self.account} signout" in command
 
 
 @pytest.mark.e2e
-def test_archive_user_exists(capfd):
-    res = user_exists(USER_ARCHIVE)
-    captured = capfd.readouterr()
+class TestE2E:
 
-    assert res is True
-    assert f"User: {USER_ARCHIVE}" in captured.out
-    assert "Google Unique ID:" in captured.out
+    def test_archive_user_exists(self, capfd):
+        res = GoogleAccount(GoogleUsers.USER_ARCHIVE).exists()
+        captured = capfd.readouterr()
 
+        assert res is True
+        assert f"User: {GoogleUsers.USER_ARCHIVE}" in captured.out
+        assert "Google Unique ID:" in captured.out
 
-@pytest.mark.e2e
-def test_nonexistent_user_does_not_exist(capfd):
-    username = f"nope_does_not_exist@{DOMAIN}"
-    res = user_exists(username)
-    captured = capfd.readouterr()
+    def test_nonexistent_user_does_not_exist(self, capfd):
+        username = f"nope_does_not_exist@{GoogleAccount.DOMAIN}"
+        res = GoogleAccount(username).exists()
+        captured = capfd.readouterr()
 
-    assert res is False
-    assert f"User: {username}, Does not exist" in captured.err
+        assert res is False
+        assert f"User: {username}, Does not exist" in captured.err
 
+    def test_nonexistent_not_in_team(self):
+        username = f"nope_does_not_exist@{GoogleAccount.DOMAIN}"
 
-@pytest.mark.e2e
-def test_nonexistent_not_in_team():
-    username = f"nope_does_not_exist@{DOMAIN}"
+        assert not GoogleGroups(GoogleGroups.GROUP_TEAM).contains_user(username)
 
-    assert not user_in_group(username, GROUP_TEAM)
+    def test_archive_user_not_in_team(self):
+        assert not GoogleGroups(GoogleGroups.GROUP_TEAM).contains_user(GoogleUsers.USER_ARCHIVE)
 
+    def test_archive_user_is_not_partner(self):
+        assert not GoogleUsers.USER_ARCHIVE.is_partner()
 
-@pytest.mark.e2e
-def test_archive_user_not_in_team():
-    assert not user_in_group(USER_ARCHIVE, GROUP_TEAM)
-
-
-@pytest.mark.e2e
-def test_archive_user_is_not_partner():
-    assert not user_is_partner(USER_ARCHIVE)
-
-
-@pytest.mark.e2e
-def test_archive_user_is_not_staff():
-    assert not user_is_staff(USER_ARCHIVE)
+    def test_archive_user_is_not_staff(self):
+        assert not GoogleUsers.USER_ARCHIVE.is_staff()

--- a/tests/services/test_toggl.py
+++ b/tests/services/test_toggl.py
@@ -20,18 +20,13 @@ def mock_environment(monkeypatch):
 
 
 @pytest.fixture
-def spy_files(mocker):
-    return mocker.patch.object(compiler_admin.services.toggl, "files", wraps=files)
+def mock_GoogleAccount(mocker):
+    return mocker.patch(f"{MODULE}.GoogleAccount").return_value
 
 
 @pytest.fixture()
 def mock_user_info(mocker):
     return mocker.patch.object(TogglTime, "user_info")
-
-
-@pytest.fixture
-def mock_google_user_info(mocker):
-    return mocker.patch(f"{MODULE}.google_user_info")
 
 
 @pytest.fixture
@@ -41,14 +36,20 @@ def mock_toggl_api_env(monkeypatch):
     monkeypatch.setenv("TOGGL_WORKSPACE_ID", "workspace")
 
 
+@pytest.fixture
+def spy_files(mocker):
+    return mocker.patch.object(compiler_admin.services.toggl, "files", wraps=files)
+
+
 class TestTogglTime:
 
     @pytest.fixture(autouse=True)
-    def setup(self, mocker):
+    def setup(self, mocker, mock_GoogleAccount):
         self.time = TogglTime()
         self.time.api_organization = mocker.Mock()
         self.time.api_reports = mocker.Mock()
         self.time.api_workspace = mocker.Mock()
+        self.account = mock_GoogleAccount
 
     @pytest.fixture
     def mock_toggl_detailed_time_entries(self, toggl_file):
@@ -63,61 +64,61 @@ class TestTogglTime:
 
         assert result == "User"
 
-    def test_get_first_name_lookup_with_record(self, mock_user_info, mock_google_user_info):
+    def test_get_first_name_lookup_with_record(self, mock_user_info):
         email = "user@email.com"
         mock_user_info.return_value = {email: {"Data": 1234}}
-        mock_google_user_info.return_value = {"First Name": "User"}
+        self.account.get_info.return_value = {"First Name": "User"}
 
         result = self.time._get_first_name(email)
 
         assert result == "User"
         assert mock_user_info.return_value[email]["First Name"] == "User"
         assert mock_user_info.return_value[email]["Data"] == 1234
-        mock_google_user_info.assert_called_once_with(email)
+        self.account.get_info.assert_called_once_with()
 
-    def test_get_first_name_lookup_without_record(self, mock_user_info, mock_google_user_info):
+    def test_get_first_name_lookup_without_record(self, mock_user_info):
         email = "user@email.com"
         mock_user_info.return_value = {email: {}}
-        mock_google_user_info.return_value = {"First Name": "User"}
+        self.account.get_info.return_value = {"First Name": "User"}
 
         result = self.time._get_first_name(email)
 
         assert result == "User"
         assert mock_user_info.return_value[email]["First Name"] == "User"
         assert list(mock_user_info.return_value[email].keys()) == ["First Name"]
-        mock_google_user_info.assert_called_once_with(email)
+        self.account.get_info.assert_called_once_with()
 
-    def test_get_last_name_matching(self, mock_user_info, mock_google_user_info):
+    def test_get_last_name_matching(self, mock_user_info):
         mock_user_info.return_value = {"email": {"Last Name": "User"}}
 
         result = self.time._get_last_name("email")
 
         assert result == "User"
-        mock_google_user_info.assert_not_called()
+        self.account.get_info.assert_not_called()
 
-    def test_get_last_name_lookup_with_record(self, mock_user_info, mock_google_user_info):
+    def test_get_last_name_lookup_with_record(self, mock_user_info):
         email = "user@email.com"
         mock_user_info.return_value = {email: {"Data": 1234}}
-        mock_google_user_info.return_value = {"Last Name": "User"}
+        self.account.get_info.return_value = {"Last Name": "User"}
 
         result = self.time._get_last_name(email)
 
         assert result == "User"
         assert mock_user_info.return_value[email]["Last Name"] == "User"
         assert mock_user_info.return_value[email]["Data"] == 1234
-        mock_google_user_info.assert_called_once_with(email)
+        self.account.get_info.assert_called_once_with()
 
-    def test_get_last_name_lookup_without_record(self, mock_user_info, mock_google_user_info):
+    def test_get_last_name_lookup_without_record(self, mock_user_info):
         email = "user@email.com"
         mock_user_info.return_value = {email: {}}
-        mock_google_user_info.return_value = {"Last Name": "User"}
+        self.account.get_info.return_value = {"Last Name": "User"}
 
         result = self.time._get_last_name(email)
 
         assert result == "User"
         assert mock_user_info.return_value[email]["Last Name"] == "User"
         assert list(mock_user_info.return_value[email].keys()) == ["Last Name"]
-        mock_google_user_info.assert_called_once_with(email)
+        self.account.get_info.assert_called_once_with()
 
     def test_str_timedelta(self):
         dt = "01:30:15"
@@ -127,7 +128,6 @@ class TestTogglTime:
         assert isinstance(result, timedelta)
         assert result.total_seconds() == (1 * 60 * 60) + (30 * 60) + 15
 
-    @pytest.mark.usefixtures("mock_google_user_info")
     def test_prepare_input(self, toggl_file, spy_files):
         df = self.time._prepare_input(toggl_file)
 
@@ -161,8 +161,8 @@ class TestTogglTime:
         assert self.time.converters.get("justworks") == self.time.convert_to_justworks
         assert self.time.converters.get("nope") is None
 
-    def test_convert_to_harvest_mocked(self, toggl_file, spy_files, mock_google_user_info):
-        mock_google_user_info.return_value = {}
+    def test_convert_to_harvest_mocked(self, toggl_file, spy_files):
+        self.account.get_info.return_value = {}
 
         self.time.convert_to_harvest(toggl_file, client_name=None)
 
@@ -171,8 +171,8 @@ class TestTogglTime:
         assert sys.stdout in call_args[0]
         assert call_args.kwargs["columns"] == TogglTime.HARVEST_COLUMNS
 
-    def test_convert_to_harvest_sample(self, toggl_file, harvest_file, mock_google_user_info):
-        mock_google_user_info.return_value = {}
+    def test_convert_to_harvest_sample(self, toggl_file, harvest_file):
+        self.account.get_info.return_value = {}
         output = None
 
         with StringIO() as output_data:
@@ -190,10 +190,10 @@ class TestTogglTime:
         assert set(output_df.columns.to_list()) <= set(sample_output_df.columns.to_list())
         assert output_df["Client"].eq("Test Client 123").all()
 
-    def test_convert_to_harvest_with_duplicates(self, mock_google_user_info):
+    def test_convert_to_harvest_with_duplicates(self):
         # Test that seemingly duplicate time entries are disambiguated
 
-        mock_google_user_info.return_value = {"First Name": "Test", "Last Name": "User"}
+        self.account.get_info.return_value = {"First Name": "Test", "Last Name": "User"}
         csv_input = """Email,Project,Task,Client,Start date,Start time,Duration,Description
     test@example.com,Compiler,Backend,ACME,2025-11-18,09:00:00,01:00:00,A task
     test@example.com,Compiler,Backend,ACME,2025-11-18,10:00:00,01:00:00,A task


### PR DESCRIPTION
Take all the one-off functions defined in `compiler_admin.services.google` and combine them into more sensible service classes to make code more DRY (and simpler to test).