### PR TITLE
Refactor: download mapping files from Google Drive

### DIFF
--- a/.github/workflows/monthly-time-reporting.yml
+++ b/.github/workflows/monthly-time-reporting.yml
@@ -37,16 +37,6 @@ jobs:
           mkdir -p $GAMCFGDIR/gamcache
           mkdir -p $GAMCFGDIR/Downloads
 
-          cat > $CFGDIR/toggl-project-info.json <<- EOM
-          ${{ secrets.TOGGL_PROJECT_INFO }}
-          EOM
-          echo "TOGGL_PROJECT_INFO=$CFGDIR/toggl-project-info.json" >> $GITHUB_OUTPUT
-
-          cat > $CFGDIR/toggl-user-info.json <<- EOM
-          ${{ secrets.TOGGL_USER_INFO }}
-          EOM
-          echo "TOGGL_USER_INFO=$CFGDIR/toggl-user-info.json" >> $GITHUB_OUTPUT
-
           cat > $GAMCFGDIR/gam.cfg <<- EOM
           ${{ secrets.GAM_CFG }}
           EOM
@@ -61,6 +51,12 @@ jobs:
           cat > $GAMCFGDIR/oauth2service.json <<- EOM
           ${{ secrets.GOOGLE_OAUTH2_SERVICE }}
           EOM
+
+          gam user ${{ vars.GAM_USER }} get drivefile ${{ vars.TOGGL_PROJECT_INFO }} targetfolder $CFGDIR
+          echo "TOGGL_PROJECT_INFO=$CFGDIR/toggl-project-info.json" >> $GITHUB_OUTPUT
+
+          gam user ${{ vars.GAM_USER }} get drivefile ${{ vars.TOGGL_USER_INFO }} targetfolder $CFGDIR
+          echo "TOGGL_USER_INFO=$CFGDIR/toggl-user-info.json" >> $GITHUB_OUTPUT
 
       - name: Lock Toggl time entries
         id: lock

--- a/.github/workflows/monthly-time-reporting.yml
+++ b/.github/workflows/monthly-time-reporting.yml
@@ -34,6 +34,8 @@ jobs:
           CFGDIR: "${{ github.workspace }}/.config"
           GAMCFGDIR: "${{ github.workspace }}/.config/gam"
         run: |
+          echo "CFGDIR=$CFGDIR" >> $GITHUB_OUTPUT
+
           mkdir -p $GAMCFGDIR/gamcache
           mkdir -p $GAMCFGDIR/Downloads
 
@@ -146,6 +148,8 @@ jobs:
 
       - name: Cleanup
         id: cleanup
+        env:
+          CFGDIR: "${{ steps.config.outputs.CFGDIR }}"
         if: always()
         run: |
-          rm -rf .config/
+          rm -rf "$CFGDIR"


### PR DESCRIPTION
Simplifies the management of these files.

Previously they were stored in GitHub Actions secrets, which cannot be viewed once created. This presents a challenge with understanding the current version/contents of the files.

Moved these files to the a Compiler shared Drive folder and instead using `gam` to download them before they are needed by later parts of the pipeline.